### PR TITLE
v2.2

### DIFF
--- a/210Pb_AgeModelPlot.ipynb
+++ b/210Pb_AgeModelPlot.ipynb
@@ -5,9 +5,9 @@
    "id": "1d518608",
    "metadata": {},
    "source": [
-    "# Welcome to the 210Pb age model script v2.1!\n",
+    "# Welcome to the 210Pb age model script v2.2!\n",
     "\n",
-    "### <div style=\"text-align: right\"> Last modified by A.A. Lehrmann 3 September 2025 </div>\n",
+    "### <div style=\"text-align: right\"> Last modified by A.A. Lehrmann 4 September 2025 </div>\n",
     "\n",
     "\n",
     "### The script below will extract radioisotope data from Canberra PDFs, run the age model (from the Wellner Lab Group excel model (Appleby, 2001; Boldt et al., 2013), and plot the age model\n",
@@ -18,9 +18,7 @@
     "\n",
     "    2. Make an /CORE_AgeModelOutput/ folder to put all of your script's outputs\n",
     "\n",
-    "    3. When copying folder paths, make sure to remove quotation marks\n",
-    "\n",
-    "    4. Always add the extension .csv to your output files"
+    "    3. When copying folder paths, make sure to remove quotation marks\n"
    ]
   },
   {
@@ -34,7 +32,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "b2b4d421",
    "metadata": {},
    "outputs": [],
@@ -50,13 +48,108 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "eda88dac-3fcf-4c27-b2ab-c9c3e8a60701",
+   "execution_count": 14,
+   "id": "e674ea42-dfe2-402d-b629-7919e8eb4aa3",
    "metadata": {},
    "outputs": [],
    "source": [
+    "# --- Helper: prefer highest version (_v2, _v3, …) for BOTH Canberra and PtSrc files ---\n",
+    "import os, re, numpy as np, pandas as pd\n",
+    "\n",
+    "# Capture depth AND optional version (e.g., 21-24, 21-24cm, 21-24_v2, 21-24cm_v3, etc.)\n",
+    "DEPTH_RE = re.compile(r'(\\d{1,3}-\\d{1,3})(?:cm)?(?:_v(\\d+))?(?=\\.|_|$)', re.IGNORECASE)\n",
+    "\n",
+    "def _depth_and_version(s: str):\n",
+    "    base = os.path.basename(str(s))\n",
+    "    m = DEPTH_RE.search(base)\n",
+    "    if not m:\n",
+    "        return None, 0\n",
+    "    depth = m.group(1)                 # standardized like \"21-24\"\n",
+    "    version = int(m.group(2)) if m.group(2) else 0\n",
+    "    return depth, version\n",
+    "\n",
+    "def reshape_canberra_with_ptsrc_mixed(df_in: pd.DataFrame,\n",
+    "                                      write_to: str | None = None,\n",
+    "                                      ptsrc_cols: tuple[str,str] = (\"Pb-210\", \"Pb-210 error\")) -> pd.DataFrame:\n",
+    "    \"\"\"\n",
+    "    Works on a single mixed table (Canberra + PtSrc rows).\n",
+    "    - For any duplicate depths on either side, keeps the **highest _vN**.\n",
+    "    - Adds H/I/J = ['ptsrc_pb210','ptsrc_pb210 error','file ptsrc'] right after 'Pb-214 error'.\n",
+    "    - Preserves your original header names (no renaming of 'error' columns).\n",
+    "    \"\"\"\n",
+    "    if \"File\" not in df_in.columns:\n",
+    "        raise KeyError(\"Input dataframe must contain a 'File' column.\")\n",
+    "\n",
+    "    df = df_in.copy()\n",
+    "\n",
+    "    # Split rows by prefix\n",
+    "    is_ptsrc = df[\"File\"].astype(str).str.startswith(\"PtSrc_\")\n",
+    "    can_df = df.loc[~is_ptsrc].copy()\n",
+    "    pt_df  = df.loc[ is_ptsrc].copy()\n",
+    "\n",
+    "    # Extract (depth, version) for both sides\n",
+    "    can_df[[\"__depth__\",\"__ver__\"]] = can_df[\"File\"].apply(lambda s: pd.Series(_depth_and_version(s)))\n",
+    "    pt_df[[\"__depth__\",\"__ver__\"]]  = pt_df[\"File\"].apply(lambda s: pd.Series(_depth_and_version(s)))\n",
+    "\n",
+    "    # **Prefer highest version for Canberra** when duplicates share the same depth\n",
+    "    can_df = can_df.sort_values(\"__ver__\").drop_duplicates(subset=\"__depth__\", keep=\"last\")\n",
+    "\n",
+    "    # Pick value/error columns in PtSrc rows\n",
+    "    val_col, err_col = ptsrc_cols\n",
+    "    if val_col not in pt_df.columns or err_col not in pt_df.columns:\n",
+    "        # Fallback: first two numeric columns\n",
+    "        num_cols = [c for c in pt_df.columns if c != \"File\" and np.issubdtype(pt_df[c].dtype, np.number)]\n",
+    "        if len(num_cols) < 2:\n",
+    "            for c in pt_df.columns:\n",
+    "                if c != \"File\":\n",
+    "                    pt_df[c] = pd.to_numeric(pt_df[c], errors=\"coerce\")\n",
+    "            num_cols = [c for c in pt_df.columns if c != \"File\" and np.issubdtype(pt_df[c].dtype, np.number)]\n",
+    "        val_col, err_col = num_cols[:2]\n",
+    "\n",
+    "    # Reduce PtSrc to needed columns and **prefer highest version per depth**\n",
+    "    q = pt_df.loc[:, [\"__depth__\", \"__ver__\", \"File\", val_col, err_col]].copy()\n",
+    "    q.rename(columns={\n",
+    "        \"File\": \"file ptsrc\",\n",
+    "        val_col: \"ptsrc_pb210\",\n",
+    "        err_col: \"ptsrc_pb210 error\"\n",
+    "    }, inplace=True)\n",
+    "    q[\"file ptsrc\"] = q[\"file ptsrc\"].map(lambda x: os.path.basename(str(x)))\n",
+    "    q = q.sort_values(\"__ver__\").drop_duplicates(subset=\"__depth__\", keep=\"last\")\n",
+    "\n",
+    "    # Merge and clean\n",
+    "    out = can_df.merge(q.drop(columns=\"__ver__\"), on=\"__depth__\", how=\"left\")\n",
+    "    out.drop(columns=[\"__depth__\",\"__ver__\"], errors=\"ignore\", inplace=True)\n",
+    "\n",
+    "    # Desired column order (keep original header names)\n",
+    "    base = [\"File\",\"Pb-210\",\"Pb-210 error\",\"Bi-214\",\"Bi-214 error\",\"Pb-214\",\"Pb-214 error\"]\n",
+    "    hij  = [\"ptsrc_pb210\",\"ptsrc_pb210 error\",\"file ptsrc\"]\n",
+    "    others = [col for col in out.columns if col not in base + hij]\n",
+    "    out = out[[c for c in base if c in out.columns] + hij + others]\n",
+    "\n",
+    "    if write_to:\n",
+    "        out.to_csv(write_to, index=False)\n",
+    "    return out\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "eda88dac-3fcf-4c27-b2ab-c9c3e8a60701",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "Operator name:  AALehrmann\n",
+      "Run date [YYYYMMDD] (Enter for 20250904):  \n",
+      "Core name (e.g., MB1901):  NBP2002 KC72\n"
+     ]
+    }
+   ],
+   "source": [
     "#add age model information\n",
-    "SCRIPT_VERSION = \"v2.1\"\n",
+    "SCRIPT_VERSION = \"v2.2\"\n",
     "OPERATOR_NAME = input(\"Operator name: \").strip()\n",
     "_default = datetime.today().strftime(\"%Y%m%d\")\n",
     "_run = input(f\"Run date [YYYYMMDD] (Enter for { _default }): \").strip() or _default\n",
@@ -66,19 +159,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "8ba6b0e9-a219-4ed8-996e-55baf5da2fe2",
    "metadata": {},
    "outputs": [],
    "source": [
     "#session metadata\n",
     "CORE_NAME = re.sub(r\"[^A-Za-z0-9]+\", \"\", CORE_NAME_RAW)\n",
-    "SUFFIX = f\"_{CORE_NAME}{RUN_DATE}\"\n",
+    "SUFFIX = f\"_{CORE_NAME}_{RUN_DATE}\"\n",
     "META = {\"operator\": OPERATOR_NAME, \"date\": RUN_DATE, \"core\": CORE_NAME, \"version\": SCRIPT_VERSION, \"suffix\": SUFFIX}\n",
     "\n",
     "def compose_output_name(basename: str, ext: str, directory: Path | str = Path.cwd()) -> Path:\n",
     "    \"\"\"\n",
-    "    Returns a full Path like <directory>/<basename>_<CoreNameYYYYMMDD><ext>\n",
+    "    Returns a full Path like <directory>/<basename>_<CoreName_YYYYMMDD><ext>\n",
     "    \"\"\"\n",
     "    directory = Path(directory)\n",
     "    base = f\"{basename}{META['suffix']}\"\n",
@@ -89,7 +182,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "23304f95-a0f8-4f28-8c7f-697050a5dd57",
    "metadata": {},
    "outputs": [],
@@ -119,7 +212,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "937424bd",
    "metadata": {},
    "outputs": [],
@@ -151,7 +244,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "a0995561",
    "metadata": {},
    "outputs": [],
@@ -199,7 +292,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "d6cef998",
    "metadata": {},
    "outputs": [],
@@ -214,7 +307,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "e43489c4",
    "metadata": {},
    "outputs": [],
@@ -234,7 +327,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "2496c872",
    "metadata": {},
    "outputs": [],
@@ -262,27 +355,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "9c29e297",
    "metadata": {},
    "outputs": [],
    "source": [
-    "#Export to csv\n",
+    "# Export to csv\n",
     "def extract_pdf_values(folder_path, output_csv_path, parse_numbers=False):\n",
     "    combined_data = extract_pdf_data(folder_path)\n",
     "    combined_df = sort_pdf_data(combined_data, parse_numbers)\n",
+    "\n",
+    "    # Use the helper to match by depth and insert H/I/J (ptsrc, ptsrc_error, file ptsrc)\n",
+    "    final_df = reshape_canberra_with_ptsrc_mixed(combined_df, write_to=output_csv_path)\n",
+    "\n",
     "    csv_path = Path(output_csv_path)\n",
-    "    combined_df.to_csv(csv_path, index=False)\n",
     "    print(f\"CSV saved -> {csv_path}\")\n",
-    "    write_readme(csv_path)\n"
+    "    write_readme(csv_path)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "47a50848",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "Enter the folder path of Canberra PDFs:  D:\\210Pb_thismachine\\NBP2002_KC72_gamma spec data\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CSV will be saved as -> D:\\210Pb_thismachine\\NBP2002_KC72_gamma spec data\\CanberraData_NBP2002KC72_20250904.csv\n"
+     ]
+    }
+   ],
    "source": [
     "# User inputs\n",
     "folder_path = input(\"Enter the folder path of Canberra PDFs: \").strip()\n",
@@ -294,10 +405,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "fead0af3",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CSV saved -> D:\\210Pb_thismachine\\NBP2002_KC72_gamma spec data\\CanberraData_NBP2002KC72_20250904.csv\n"
+     ]
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "Notes for CanberraData_NBP2002KC72_20250904.csv (optional):  Samples run by Jamie Jetton\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "README created -> D:\\210Pb_thismachine\\NBP2002_KC72_gamma spec data\\CanberraData_NBP2002KC72_20250904_README_20250904.txt\n"
+     ]
+    }
+   ],
    "source": [
     "#Execute functions\n",
     "extract_pdf_values(folder_path, output_csv_path)"
@@ -309,28 +442,6 @@
    "metadata": {},
    "source": [
     "### Make note of which samples are missing data! This will be important when we plot!"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "6d5ac233",
-   "metadata": {},
-   "source": [
-    "# Open the output .csv file\n",
-    "\n",
-    "Check to make sure all radioisotope data translated correctly. \n",
-    "\n",
-    "# Create two new columns\n",
-    "- ptsrc_pb210\n",
-    "- ptsrc_pb210 error\n",
-    "\n",
-    "# Move Point Source Lead 210 data to ptsrc_pb210 and uncertainty to ptsrc_pb210 error of associated samples\n",
-    "\n",
-    "# CHECK the following\n",
-    "\n",
-    "Radioisotope data should have the following headings\n",
-    "\n",
-    " ### | File    | Pb-210   | Pb-210 error    | Bi-214  | Bi-214 error   | Pb-214    |Pb-214 error |  ptsrc_pb210    | ptsrc_pb210 error  | \n"
    ]
   },
   {
@@ -357,10 +468,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "id": "776436fa",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "Enter the path to the sample weight CSV file (e.g., /path/weights.csv):  D:\\210Pb_thismachine\\NBP2002_KC72_gamma spec data\\output\\NBP202KC72_weights-allnewdish.csv\n",
+      "Enter the path to the Canberra data CSV file (e.g., /path/canberra.csv):  D:\\210Pb_thismachine\\NBP2002_KC72_gamma spec data\\CanberraData_NBP2002KC72_20250904.csv\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output file will be saved as -> D:\\210Pb_thismachine\\NBP2002_KC72_gamma spec data\\AgeModel_NBP2002KC72_20250904.csv\n"
+     ]
+    }
+   ],
    "source": [
     "import pandas as pd\n",
     "import numpy as np\n",
@@ -381,7 +508,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "id": "03e60839",
    "metadata": {},
    "outputs": [],
@@ -402,10 +529,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "id": "7dcb329d",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "Enter the year of core (e.g., 2023):  2020\n"
+     ]
+    }
+   ],
    "source": [
     "# Prompt the user for the year of core\n",
     "year_of_core = int(input(\"Enter the year of core (e.g., 2023): \"))"
@@ -413,9 +548,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "id": "0af4c96e",
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "# Calculate activity and correction factors\n",
@@ -431,7 +568,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "id": "3bf63be5",
    "metadata": {},
    "outputs": [],
@@ -449,7 +586,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "id": "01701f14",
    "metadata": {},
    "outputs": [],
@@ -469,7 +606,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "id": "201ee0a3-542e-41d4-8c9f-bd3bc03734da",
    "metadata": {},
    "outputs": [],
@@ -488,7 +625,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "id": "c1351d3e-beb4-4ea2-9e86-2a65bffe3466",
    "metadata": {},
    "outputs": [],
@@ -526,7 +663,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "id": "27100ef0-5287-4279-8cfd-043cc3f0c9ed",
    "metadata": {},
    "outputs": [],
@@ -545,10 +682,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "id": "503d79cd",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CSV saved -> D:\\210Pb_thismachine\\NBP2002_KC72_gamma spec data\\AgeModel_NBP2002KC72_20250904.csv\n"
+     ]
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "Notes for AgeModel_NBP2002KC72_20250904.csv (optional):  Samples run by Jamie Jetton\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "README created -> D:\\210Pb_thismachine\\NBP2002_KC72_gamma spec data\\AgeModel_NBP2002KC72_20250904_README_20250904.txt\n"
+     ]
+    }
+   ],
    "source": [
     "# Calculate 'calendar years pre year of core'\n",
     "data['calendar years pre year of core'] = year_of_core - data['Age bp']\n",
@@ -572,10 +731,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "id": "80727060",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "Enter the full path to the age model file to plot (e.g., /path/to/age_model.csv):  D:\\210Pb_thismachine\\NBP2002_KC72_gamma spec data\\AgeModel_NBP2002KC72_20250904.csv\n"
+     ]
+    }
+   ],
    "source": [
     "import matplotlib.pyplot as plt\n",
     "import matplotlib.colors as mcolors\n",
@@ -589,10 +756,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "id": "e3938c61",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "Enter the core name for the title:  NBP2002 KC72\n",
+      "Enter the depths (comma-separated) where 'calendar years pre year of core' should be labeled (or type 'all' to label all intervals):  all\n"
+     ]
+    }
+   ],
    "source": [
     "# Get the core name for the plot title\n",
     "core_name = input(\"Enter the core name for the title: \")\n",
@@ -608,10 +784,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "id": "282ccf1b",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "Are there any intervals with undetectable amounts of radioisotopes? (yes/no):  no\n"
+     ]
+    }
+   ],
    "source": [
     "# Ask if any intervals have undetectable radioisotope amounts\n",
     "missing_data_input = input(\"Are there any intervals with undetectable amounts of radioisotopes? (yes/no): \").strip().lower()\n",
@@ -625,10 +809,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 31,
    "id": "a581232a",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "Enter the full path where you want to save the plot PDF (e.g., /path/to/your/directory):  D:\\210Pb_thismachine\\NBP2002_KC72_gamma spec data\n"
+     ]
+    }
+   ],
    "source": [
     "# Define colors for the data series and error bars\n",
     "excess_pb210_color = 'black'\n",
@@ -644,14 +836,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "id": "87b65633-9682-48ce-be5c-f00753689c29",
    "metadata": {},
    "outputs": [],
    "source": [
     "def save_figure(fig, basename: str, directory=Path.cwd(), ext=\".png\", dpi=300):\n",
     "    \"\"\"\n",
-    "    Adds rotated footer 'Created by <Operator> 210PbAgeModelScript v2.1'\n",
+    "    Adds rotated footer 'Created by <Operator> 210PbAgeModelScript v2.2'\n",
     "    along the right axis spine in light grey, saves with suffix, and writes a README.\n",
     "    \"\"\"\n",
     "\n",
@@ -685,10 +877,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "id": "0725028d",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Figure saved -> D:\\210Pb_thismachine\\NBP2002_KC72_gamma spec data\\AgeModelPlot_NBP2002KC72_20250904.pdf\n"
+     ]
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "Notes for AgeModelPlot_NBP2002KC72_20250904.pdf (optional):  \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "README created -> D:\\210Pb_thismachine\\NBP2002_KC72_gamma spec data\\AgeModelPlot_NBP2002KC72_20250904_README_20250904.txt\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjQAAAHoCAYAAABen3XKAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAAbVhJREFUeJzt3Qe4E1X+//FDFelVepUuIkoRELEh6A8VXXsD0VXXxYJlbauirt21r2XXteHa3QXbghWxgGJHpAnSe++CQP7P5+z/5JnkJrnJvUlm5ub9ep4QMpmbO5k7yXznnO/5nnKRSCRiAAAAQqy83xsAAABQWgQ0AAAg9AhoAABA6BHQAACA0COgAQAAoUdAAwAAQo+ABgAAhB4BDQAACD0CGgAAEHoENACy7pxzzjHlypWz90BQ3XzzzfY4PfTQQ01Zc3OO3pteT6+r1w99QON2km5Vq1Y1S5cuTbru/Pnzo+t+/PHHSXdM/K18+fKmZs2aplu3buaqq64yCxYsSGt7vLcqVaqYZs2ameOOO868+uqrJtEMD5s3bzavvPKK+f3vf2/2228/U6NGDVO5cmXTqFEjc9RRR5lnn33W7Ny5s9h9smPHDnP//febnj17mlq1apnq1aubfffd14waNcps2rSp2J/XOnof+hn9rF5Dr3XffffZ105myZIl5rHHHjMnn3yyadu2rdlzzz3trXXr1ub00083H330kcnGSalVq1Yp1/vLX/4S3e/alvht3rVrl/0bDB061LRv397Url3b7ue99trL9OvXz1x33XVm2rRpSX9/urf442T79u3mrbfeMhdffLHp0aOH/b2VKlUyDRo0MIcddph55JFHzNatW0u8f7Lx+p9++ql56KGHzLBhw0yXLl1MxYoVM/4SKu3xl4vPVq7pmEw3YNLn2G27vpPgP/1NdHwlOi+E1bp16+z3rzvWfv7555z8nu+//97uuwcffNAEzYMPPmi3Tdvoi0iGRo0apW+v6O2CCy5Iuu68efOi602YMKHI84cccoh9rlKlSpGGDRtGb3Xr1o35HXvuuWfkv//9b7Hb432NKlWqxLzG0UcfHfn1119jfrZt27Yx61SuXDlSo0aNmGU9e/aMrFy5Mul7XLt2bWT//fePrr/HHntEqlatGn3csmXLyPz585P+vJ5r1apVdH39rF7DPdZr63fEW7hwYaRcuXIx26qf1b7yLjv33HMjO3fujJTEsGHDou8hkd27d0dGjhwZ/V3nn39+ZNeuXTHrTJ48OdK+ffuYbdLfW3/j8uXLxyz/3e9+F9m+fXv0Zy+99NKYv2miW4UKFezPNm7cuMj7HDBgQMzrV6xYMVKrVq2YZToGfv755xLtn2y8vndd702fjXSU9vhLpTSfLXfs6D4X9L7Sff1nnnkmuq36ToL/3He/jjE/uWM83c9bKo888kjM5+Laa6+N5II7npN9L3u3p0OHDpGzzz47kk16Pb2uXj/Z51Lb6IdSBzT6Ep81a1apAppEB9O2bdsiL7/8cqRevXp2HZ0AN2/enHJ7vHRinTZtWuTII4+MPn/VVVcV2fmdO3eO3HvvvZGffvopunzZsmWRa665JnqyPPjgg+3JOxF9mWudmjVrRl555ZXoCf29996zJ1k9t++++yYMKn777Tf7nDshv//++9Ft13t3wdX//d//Jd23RxxxROS5556LLFmyJPqzei9DhgyJvu8bbrghku2ARu/nnHPOif6Oq6++usg6b775ZjQ409/xzjvvjMyePTvmNb766iv7wdf+03rr1q1Le/uWL19uj79kXx46rrTtN998c+Tbb7+N/m0UBNx9993RE7+CDh1vmcrG6ysA7dWrV+QPf/hD5Mknn4wMGjQooy/Y0hx/xSnNZ4uABoUW0HTr1s2+1iWXXJL0IiufAY0fQhvQNG/ePNK1a1f7/xNPPDHrAY3z/PPPR18jUStNsi9dRycS1xKjAEFBhKNtShaoiE7A7rU//fTTIs9/8MEH0edfeumlIs9PmjQp+vw///nPIs9rmXte68Z78cUXo8/rd3mtX78+8s033yTddr2vo446yv5s9erVS3TCThbQ6Gr8hBNOiG6bTt7xFLi4IEVB46JFi1L+rjVr1tggLJOA5q677rKvr5aqRK0g+pt5/97x9Ddz70HHWaay8frxX3hun6fzBVva4684pflsEdCgkAIafRfrdWrXrm0/F61bt7aPdVGXbQQ0yZU4KVh5Lnfeeaf9/7///W8zZcoUkwvKo/HmvGRK/f3K6xDlE8ycObNIDk8y5513XvT/X331VZHnn3vuOXvfpk0bc+qppxZ5vk+fPtFciNGjRyf9eeVbaN14p512ms2HSfTzypU44IADkm673te5554b3W8zZsww2aDXGjx4sBkzZoypUKGCefLJJ83VV19dZL0bbrjBbNy40e5/rauci1Tq1q1rxo4da99Xup5++ml7f8ghh9gconjKz1FOSjKnnHKKzZtK9vctTjZeX/uwpEp7/JVWqs+Wly6cnnjiCdOrVy+bG6eb9t2LL75ogpY4+eGHH9rjW3lQen+dOnUyt9xyi/n1119Tvs6aNWvMrbfeag488EB7LOtnleczcOBA8/jjj5sNGzYk/Ln//Oc/5phjjjENGza0eWW612N9ZtJJuNa+/ec//2n3Z7169exy5afEJ2/+9ttvNifP5XolymtUHtsFF1xg2rVrZ/MjlYvVtWtX8+c//9msXr065fvfsmWLzePSZ7F+/fr2vegzr8f6vStWrIjJZ5o4caJ9rH0bn6OVKM/p888/N2eddZZp2bKl3bf6ntDxdPfddxd7Xhg3bpw58sgj7fvWe1K+5D333GP3SbY89dRT9l6fQ22f8gW931HFee+99+z3vd6f8nB0DGnfX3LJJWby5MnR9bR/hg8fbv+vnMH4fXezJ1E3UVKw3rP+Plr+8MMPp9wmbbvW0+fVmwuYKCnY/S6Xx6htjN820feA/q/3l+oztXv37mieXEbJx5ESRrQuOnSR9mGHHZaTFpp//etf0df44Ycfkm5Pqrfy6KOPRtf5/PPP036vGzdujP6cuqXiNWrUyD73xz/+MelrqPVC6yhfZOvWrdHlW7ZsieaQ3HPPPUl//qKLLrLr6HdlSlcHbvvVtVPaFhq1oqh7xOUbvf7660m7gtx7O++88yK58Mknn0Tfm46RknL5WiNGjMjq9pX09TNpoSnN8ZeO0ny2vC00p556anQb6tSpE5P7NXz48JStpLluofFeoetzqG3TTVfa3u3U91uy7oN3333Xvi+3rrpB1cWqXDG3bMyYMTE/o1wxt1+8+8abV3b66adHduzYUeT3uX07dOhQ2zoe//Pu6th9v6r7vG/fvtFtc38D73eyjhPv71Z3qT7j7rG6T9Stmqx1Qi323vei496bC/jAAw/YddWVrjwst2+qVatWJC9O+YHe7k3l0rnXcS3OLh1AN+VzJMsTi0+R0N/VdVP3798/ct1115W6hUYtMnpd72dg7ty5dh/rd+n7MBmdB04++eSYbVRrpzcXb7/99ouur/3jWr61n+P33b2e81Sy1id9F2l5jx49Ur6vQw891K6n1ILiWtf0e/X73TGkbYzfNndO1d+vuFbxcePG2XX0d/YeD8UpdUCjpE+347UR2Qpo1K3x2muvRRo0aGDXGThwYIm/dP/0pz9F15kxY0aJAoLx48fHPLd69eroc4899ljS13jnnXei63m7iL7++uvo8mQJz/EnDAUUmbjiiiuiwceGDRsipQlolKOzzz77RL+EXL5PcV0tb7/9diQX9GWu19eXc0m602Tq1KnR7XziiSeyvo0lef10A5rSHn/pKM1ny70PfTHri/0vf/lL9BhUkv3FF18c/bmHHnoo4ndAoxOSvox1glu1apV9Ttt70003RX/2qaeeKvLaOsm7JGl9PvRZdkGIAiB9zq+88soiXcZapp/RvrnxxhujXa3Kv7r++uujv1PBSDy3b3Vi0Anzr3/9a3Tfbtq0KbJ06dKY71etp5v2gwtqdfy47xPX9a11br/9dptD6N3+ww8/3D7frFkz+/peOtnUr1/fPq+gRgGLTtKiQFX5fMoxi7/oSLfLSfl/Wm+vvfay34Vum7WPdU5xCfEHHHBAkQEJb7zxRnQ/KmhwJ0btA72WvhddIFKagMZddKv71Uu5l8VdsJ5yyinR4ER/a2/XvI7DF154webXlaTLaVSSgObLL78s9ny4YMGCaED/0Ucfpf23S6fLSe/HBZTJaICI1jnmmGMimSh1QCMun0JJUd6rrWyMctKHRAmnya4ui/vS1Qe9SZMm9nm9bvxBn4w+MC5HaO+99y5ypeQ9WemDk8z3338fXe+tt95KGCwlanlyxo4dG13vxx9/jKTrl19+iSalljTL3X1xKmhwfcLah1988UVaX0K6uWTlbNLf1L03nRhLyiXU6kst02AxV6+fbkBT2uMvHaX5bLn3oZtO2ImcddZZ0Z/NNCjNdkCT6uTqvlw1qi1ev3797HPt2rWzeW3pWLx4cbSVQAFUqosRfTe6ACXRvn344YeT/h73/Zoql0NXzO6kHn/R5ig3qnv37jEtLfF/Q7VIZXIlnU5Ao7+VrtCVOK/jONn2K9BK1Aqm3D33WUr0va+LDLd/ShPQqPVOr3HrrbfGLFeSv5Z37Nix2By4VBcl8Uob0IhatVIdf3fccYd9vkWLFkVaUEsb0Hi/k2bOnFnkebVouRa8THOQslJY74477rC5ABp7/tJLL2X88+rXUx+ru61duzb6nPqe9ThZH3Qy69evt/3hhx9+eLRWzmWXXWZzf9KhdadOnWr78P72t7/Z+iJe3voe6m9Oxvuc92dK+/OpbNu2zeY2qN9T/aV33XWXKW19hXnz5tn/q2aM8gSKyydw1Feabcq9cH263jynTKgPXX3ron74bG9nrl8/l8dPNj9bygdQLalEbrrpJnuvz/f7779v/LTHHnsk3c4hQ4bYe30feKnOyGeffRb9Dkw3/0s5h6pvpVyLa6+9NuE6ykHTNum78fXXX0+4Tp06dcyFF15Y7O/bZ599zLHHHpt0W/T33H///c2gQYMSrqM8MdW1knfffTcmb0Z1vETvo3nz5iablG+jGlaqCaa8l0SUo3b88ccX2Tb9raZPnx7dl4mOzfPPP980bdq0VNv4yy+/2FwknSfOPvvsIjl0Ov6VWzZp0qQiP+vya1R/6qKLLjL5dPb/39YXXnghYR2p559/3t6feeaZKfNMS0J/S5cz+o9//KPI888884w97pWD9X//938ZvXZWApqOHTtGE5VuvPHGjJOtlDj2/1uLojcFMB988IFNjFLSmxLAiitU5E1A0od9wIAB5ptvvrHPKaFMyW3pUBKbEvnc+9EHKiz0RXnGGWfY960gTAdskyZNSvWaSjZUQTy5/vrrbSKjn1wCXvfu3WOSxtOlYnAKzETJe0qEzKZcv74fSvrZUhKqkgoTUfKpSxb/+uuvjZ900lfCaCLu8+O90BJ3ktLF3NFHH53273LvVYUQk+0b7WPtO+/68fTzSr4tzkEHHZT0OSXbigYNqKBospsSnsVbvFLb5b7rkwVMpeG2TQmzqbZNJ8BE2+aCsYMPPjjh6yvIKW0VXf1una/0O+ILkOpv64It952V6PhREni+nX322fazvHDhwmiCtqPPtRtE4pKbs+0Pf/hDdLCCtxCrS3J3F6uZDprI2tQHykRWNKqIVZnMpaWD4YgjjjD//e9/beb3okWLir0a0QgBd2vRooUdBaSdooq5ijjT2Tmq7uqu1EaOHGmz8BNxo1ckVTVY73PenyntzyeiqxlF1BotpA+yWjI0yqK09EWvq5AOHTrYLzBl8ie7anQBkBN/EigtXXm5LytVeM6URo9oHymL/sQTT0z4RVMauX79XB4/ufhsFXcF7J5fuXKl8VOqfeNGssVXDV++fLm9VytotWrV0v5d7r0Wt29csJds36jSdjpSreda2DTixNtKHn/TiMX448m9f9F3dLa5bVNLUKpt0/Px2+b2mf42aulKprjRl6noM+5GlCU78asCuLvIiR+N5fZfLvZdcfQZVkOCtzXGcY8VMKuxIhfUeqVWa42e814g6/tk7ty59vukJN/vWQto9OHUEDO57bbbSjTEOtkXjRuSOmHCBLNs2bKk6+oAcTdF64o0Fe1pWHQ61LV06aWX2v+rnP0DDzyQdF1vq4emIEjG+5z3Z0r784mCGV0p64Ojg+Ff//qXOemkk0y2NG7c2AY1GsaqL3Y1Qet3Jbvadb777juTTS56V1eKWqIyoUBPx5K2/4QTTjAvv/xyymHXmcr163tl+/gpTmk/W9mmiyfXvVoc74nO/Vw2ZLspPlPpXr2mWk/fG6LjNr6VPNHNO6Q61+/fbds111yT1rblexoFdXEtXrzY/l8n30TThLjWfZ0P478v/T5+hv7/IEwXp+5zpO8ulzYS34WWTepuddOWeLudVAZE1OJZkmAzq5NTqh9VTaWKjtVtky3eCDZXc7GoZcYFZCNGjLCPU1ErhJo7JdE8RI57Ts2bCgYc/d/166bz8/pdyfIwXMuMTqAumElUl6S0tA0KKjt37hzt2nJ96F46ybn3lqqeRknmTlIXmihHKFlzfSLaDl0VqIVJzcDa7mwGG7l+/Wwff/mSKtjyPp9ua4OjK+90Xt+7jvZBNnOZ3P7XVaZrJUiHe6/uZJiMez7TfVOS95BqvrzifrakP5/u65fktd0+09+muPnwSirT1tf49Uvz/rLhpJNOsgG+Wt/eeOONaPeezt9KV3B5U7miHhdXD2nOnDn2b+XOF+nkhuU8oFEw45LcFNCsWrUqK6/r/eBn0rSbLgUv3pYZtdSkQ8WaXKSebIK+8ePH23sVvvJeHaqFwfVtu3Xi6TVdoluyriMFMy6wcMGMCjTlirocFNSoFcYFUvGJ4FpH3S2ibq/Zs2en/fqpJjpU06TrwsokGVg/pwDPBRu6UopP8i6NXL9+Lo6/fFH3YLLWWn2Juc+2yxdJl/KnXAtgccGES9xVPl42/y59+/a19/ocuATwdHhzY5INdlCirjfXJlfcd5Ba3FK1fid7Hy6HR5O0ZsJd8KT6vLttUy5lcYUNE22b6MJLE8Am6zIqaauOzm1vvvlmtIVDCffJbq7orHJmZs2aVeT4ycW+S4c3odp1M7l7tZC4i4ZcbZvyMjWwQOuqZcbl0yi5PJOctBjZGLbtpeHVbhjdsccem9aw7VRD5jSc0w0xU52E+Enw0qmVkYqGPbqf1xwcmfAOu9M8OvE0vDmdqQ803j/RUGi9pvv5+DoWrk6EK86lYaCqAZFNqeZyUi0RNw+VhlbG15nQ/F6ugJLqc2ioaiqqv6HhsammPtC8VXo9HQ/p+s9//hMdAqjyAokKlZVGtl+/pFMflOT4K05pPlveocXJhua6dUoybNs7rYOGmCbz2WefRetpJFovndL3+u5Kth9US8MN20631lM6w7ZdfZ9Uw7aLG7KeztBofd7csO3TTjstZZFDDX2O/3y6elCZDtt2c82paF4yc+bMie6nRHPFxRcqjK+R06lTJ/uzGladaNi2G1ZdkmHb9913X7TOkndC3WQ0dFvr6+/qqL5LSYZta3i6K16Xyqg0jm1XwE77WdPVuMmNkxVNLe64UhFAPXf//fen9V5Ua87VGXLn+dJMh5H1gCZ+jqLSBDTxkywmKjJVmi/dv/3tb9GfveyyyyKlqTWiA/vVV1+NfnB0snE1OtKZnLJp06bRoEWvoddyFSH1O+Lp9fQF5A5GrZ9txc22rcJPrlaPCkPFV37UB89VG1XxLc295J1zSe9BhclUp8R9qSYLaFRXx52YUhWqiq/h44INVVRNNe9SSWTj9fUlrP3obu5vqsqu3uWJZlwv7fGXj4BG26VjQ8GEaoaI3o+3+mt8bZN0eavkKjDwnlBVE0bfQ66Cb5s2bRIGHKUNaL777rtoYb0uXbrYE4S3sN6UKVMiF154YZFClN7Ceire54573XvrOKUqrJeNgEaeffbZ6O/T8aRA2B1Hup8+fbot3qeTcvxnXIXgvIX1FFi7mmEKjlQ7SxOXjh49Oubn/vznP0eL0aW62Lnlllui26Z6Wt5aXPq8af9rHf3u+Pn2dLHhflYXfq5onYLnxx9/3FYyLmlhPVfjRgFdOvQdp/VVZ837PeE+7zqGNcFufGE9BV3nnntuzGvpOzTVhUwmx7aOUVdxXJWDda/PTHzDQbrH1Zlnnhn9/kr2neWlfeF+v7s4Lm7ev7wHNNpJLiItSWE93VzhNO8BmejqtzRfut7S5vG/P/6W7EpCfzRXrVI3fbl5t137KVlZblc8qlWrVtH19bPuC1I3vXaiA2PixInRdRLtv/hbSVpvigtoXMVRF5XrQ6mZv+OvkN0Ehu6mIEdX5d5S6/pbJCv1Lu5LXu91xYoVaW2/KwboAqpU+0etK5nKxut7WzJS3ZL9DUp7/OU6oPFOfaAvq/ipD3RCSLfYZTwFSIMHD47ZT2oVjP8d7du3T1jAKxsBjZv6wFuqXsdoOlMfuCqxJZ36IFsBjegE753qQCf7+PeQbJoRVaDWBZn3pKSf9X6PxQetag1wz7sS/jpWdfOe0BQUKRjw/j3ViqDX905/oJu+a+K5wMndtI9dq48q+ZZk6gNvdfx0i1V6C2HqQshRVWVXuNHddCGbbOqD+NZqN1WC23cPePZzuhNvuiKO7qYAvKTHlc5L7m+lv4+mzHDblow3gM+0MnBeApr46Li4gCbRTQe7ThiKYOOnVMjWl246JxJ3S/XloS8nXcGomqYOLk0NoKs1XXml0wytL2atq5/Rz+o19Fp6zWTNmd4v2XRuJZn9NJ2ARlQF151UvXPJeANcTYeg6F3BjT6w+qJUEKBKq/rSSXbCEZ3wXDemPvzpclUr07mVpFJoNl6/tAFNNo6/XAc0OimpSV1XgNo+BR19+vQpctVeEnptTe+g7wl9X7g5iHTVN2jQIFsNNlV3VjYCGtcFq+NYnwMd3/r+0oWKtuHvf/970r+DmvbVKqIpXnSi1b0e6/szmVwENO7iSq0pOoHqPbgAVH83dcerlSlZ8KnvMLXA9u7d27Z66G+gVhPNB6Tuh0QXIQoMjjvuOBvMuCAj2YzoapnRnGXqRnJTPuj7Qy0B6sZRF2Qymn5F0zfoPen4UIultlXBYklm2/7973+fUXdTfBeYUjESbaMuetSqqn2ngE2t37qQ1lQF8dSSd/nll9tg3Rs4jvL8rdN9b97KvenMd1jccaXpP1RVW+/BG6Ano0r5mQaIyZTTPyXLvgEAACg5DSBS7TclA6sifabF9HI2ygkAACAdGiHoqvJrKorSBDNCQAMAAPJKw+ZHjRplKwOrHIubDqE0clf5CwAAwEN1e9TFpJpibsJcTTHUoEEDU1oENAAAIC9UaFPVkVXkUnNFqZitqvNnA0nBAAAg9MihAQAAoUeXE8pMgtnSpUvt/CR+z2ILhIUa6JXHoJnY3Tw8QFgR0KBMUDCjOgYAMrdo0SLTrFkzvzcDKBUCGpQJaplxX8w1a9bM2usuXLjQtGjRIqvrJ1sn3eWZPM50+/3YJ6meT/RcOsuS7YMw7I98HiMbN260FwLu8wOEGQENygTXzaRgJpsBjb7oM3m9dNZPtk66yzN5nOn2+7FPUj2f6Ll0liXbB2HYH/k+RoRuWpQFdJoCAIDQI6ABAAChR0ADAABCj4AGAACEHgENAuXRRx81rVq1MlWqVDEHHnigmTJlit+bBAAIAQIaBMYrr7xirrjiCjsD67fffmv2228/M2jQILNy5Uq/Nw0AEHAENAiM+++/35x//vlm+PDhpnPnzuaJJ54wVatWNU8//bTfmwYUtO3bt5utW7faeyCoqEODQNixY4f55ptvzHXXXRddplLsAwYMMJMnTy6yvr5YvV+uKhCGzPz666921tuWLVvax+7/6u4DRNMiqAr3b7/9Fl2mWZIbN26c9Xo+QGkx2zYCQV+aTZs2NZMmTTJ9+vSJLr/66qvNxIkTzZdffhmz/s0332xuueWWIq/z448/ZrXqqa5K1UqUzfWTrZPu8kwep9oeBYHKUerVq5d97P5f3Ikq2/sk1fOJnktnWbJ9kOm2l/VjRAHLvvvuazZs2FDk76515s+fbxo0aGBq1aplKlasaHbu3GnXXbVqlQ1+q1Wrlvb7BnKNFhqEklpylG/juBLuKueezStHbwtGttZPtk66yzN5nGp7dGLSCcuVxHf/18mrtO8xk/VTPZ/ouXSWJdsHmW57WT9GUrVsKnetYcOGpl69etFllStXtgGOWk8V1BDQIEgIaBAI9evXNxUqVDArVqyIWa7HjRo1KrL+HnvsYW8AcmPbtm1JJ6xU0EuyPoKGpGAEgq78unfvbj788MPost27d9vH3i4oAPmjbqZMlgN+IqBBYKgL6cknnzTPPfecmTFjhrnooovMli1b7Kgn5M73339vSKVDPCX/JhvVpOV6HggSwmwExqmnnmr75W+66SazfPly061bNzN+/Hjbj4/cWLRokbn44ovNAw88kLR7AYWpdu3aZvXq1TZZP54+p8XlWgH5RkCDQNHJVTfkx7///W+b2KmTFzkR8FIysHe4ttdee+1FCw0Chy4noEBphItq/AwbNswcdthh9iQFOC6YUY2o+Jty3sqVK+f3JgIxaKEBCtSLL75oT04jRoyw3Qc6SQHO7Nmzkz7XpUuXvG4LkA4CGqAA7dq1y/z97383/fr1M02aNPF7cxBAnTp1KtJio27JbBauBLKJLiegQKY5mDVrlr2XMWPGmHnz5pmjjjrK701DQKkulPemKTGUIKyEYCCICGiAAqBhtupCcMNwH374YdO+fXvTqlUrvzcNIaK8GdWHYpg/goiABijAujOffvqpOfroo/3eFAScupnUIqO51jSEW8FMx44dSQhGIBHQAAXmoYcesjVn+vbta9q2bRudRkItNkwnAe/UB3PnzrXdlOvWrbOTVf788892ORBEBDRAAVFSp0Y3XXDBBWbPPfc07dq1s7kRunXo0MHeA24etcaNG9tJXzUZpSYuVQK5il4CQURAAxSQp59+2s7DM3ToUL83BQGnlpj4mes1vN8llgNBQ0ADFAgV0XviiSfMGWecYXMgVIMGSIdLAlYwoxFPQBBRhwYo4+bMmWOnk3j33XdtQbSDDz7YTJo0yeZFAMkon0oBjLomXReUjhkqSiOoCGiAMkozld977712BnOdhK666iob2Gjepg0bNpivvvrK701EgHkDF833tXPnTptMXr16dV+3C0iGgAYog90Dr776qrnyyittEvC1115r/vCHP5ivv/7aBjNulmSmOkAq3sClZcuWvm4LkA4CGqAMmTZtmh3BpHyZIUOG2KBGXUxqkQEybeHTiCaNcNLoJtcFpYDZdUMBQUJSMBCCqQqSLXMUsFx++eWmW7du9iQ0btw4M3bsWDvUFigJFdNTV5MCGTdUW4X1li1b5vemAQkR0AAhmKrAu8w7OkknGHUvqSiecmVuv/12M378eOZoQlaqBDds2NDeXDE9tcx4j0kgSAhogJBSToyq/V599dVmwIABtvXmmmuuodovskI5VgpqNExbgbObpR0IKgIaIGQ0dFZ5Mr169bJXzq+88op54YUX7EzIycRPbcBUByiOEsgXL15sNm7caB/rfuHChYxyQmCRFAyEhIbNvvPOO3bqAl01a8ZsjV5asmRJsT/rpjZI9hiIp0kpRceXCjEqj0Y5NY0aNfJ704CECGiAENDs2BdddJGZPn26OeGEE2zF3wYNGvi9WSjDOnXq5PcmABmhywkIKCX/qntJo5f69+9vKlWqZO68805z8803E8zAN4xyQlDRQgMElIrivfzyy2bMmDHm3HPPNUcccQT1ZJA3W7duNWvWrLFdnfH1aVzpgNatW/u0dUBRBDRAgEvPK29Bibt33HGHHS7LdAXIF+XOKAG4atWqRQKd+Fm4gSAgoAECPGxWQ7MPOOAAWwtErTNMV4B8UctM48aNiyzXJJX16tXzZZuAVMihAQJKtT80K3bv3r393hQUoPiWmeKWA34joAECQDkJc+fOjZnWYP78+Wb9+vW2hSbZlAdArrgJKdVSo3pHLpemVatWPm8ZkBgBDRAAyo+ZN29eTFn5H3/80daL6dixY5FpEIBcU1VgFdKbOXOmDbZ1r8euajAQNAQ0QIBnzu7ZsyfVfOHbKDvNtN25c2dbyFF1aVyBPSCICGiAAFLNGV0RH3LIIdFlbroCEoORD5rqQFWBFdSIgpomTZqYTZs2+b1pQEIENEAAqYtJo5o06WT8dAW6B/LR5VSxYuxAWLXQRCIR37YJSIWABgigjz/+2LbIHHjggX5vCgqUghnNti0KYpTD5WrTAEFEQAMEaKoDtcro9v7779v8GZ1E1MSv54B8qlWrlh3d5AKaOXPm2BaaRLVpgCCgsB4QECozr7ozmtFYQ7bXrl1r/vOf/5jNmzcXafoHck3FHB3lbukYVEADBBUtNEBAqPpq37597USUL7zwgj2B3HLLLTYRU9MgAH7k0agWkrvpMRBUBDRAQGj0kpr5devWrZv57LPPbFBz8cUXm9WrV/u9eSgwmoRSBR1XrVpl/69jUI/1fyCICGiAAFdqnThxotlzzz3N9ddfb08mQL4sXbrUDttu166drQ6sez3WciCICGiAAGvatKl5+umnTY0aNczgwYPN1KlT/d4kFAiNcKpTp07MMj12I5+AoCGgAUKQW3P77bfbXJrDDjvMTokgmtspfo6nRHNCASWh4dlKSPfSiDuGbSOoCGiAEKhZs6Z58803bbP/GWecYSZPnmyHdKsAn3dId6I5oYCSUGVgzd2kEXfqZtL9okWL7PJly5ZFb0BQENAAAaAieq1bt044b5OShTVsVsNoVZ9Gc+oMHDjQfP75575sKwqDas8oQV2J6ZqQUvd6rOUa7eRuQFBQ3AIIAE1nsPfeeyec1kDLlCDs/v/ss8+aSy65xJx00knm2muvtQmbQLY1a9bM700AMkILDRAyVatWNW+99ZY5+OCDzW233WZHQgFAoSOgAUJIQ7mff/550717d3P55ZfbisIAUMgIaICQUr7NyJEjbWXhU045xfz88892HijmfQJQiAhogBDTfE+dO3e2yZkfffSRnQtKc0IBQKEhKRgIMc3xtHXrVvt/tdRoYst169b5vVkoA9Jt6dMoPCAICGiAENPJRHVBXHCjobWcYJANqnGUji5duuR8W4B0ENAAIeeqAitRmLL0yBZVplZlYAXKlSpVssfWypUr7TQcqkcDBA05NECIA5nFixdHu5xEicEENcgGzbKtWjQKlNXyp3s91nK1CrobEBQENEBIaXoDlaRXQKNuJgUyc+bMIaBBVqg6sG7FLQOCgi4noAwENokqDAOloW6lBQsWmAYNGkS7nNQ6Q3cTgoqABghxHRrlOWiYtroDRCceTZOQaE4oIBONGze2AcyKFStsMKNjq3bt2jbAAYKIgAYIKbXKKKfhu+++i7bQqOtJczvRYoPSKleunE0I1g0IA3JogDLQ5eRaaIDSWL9+fdLnVLxRrYHK0wKCiBYaIOTFzzZv3mxHoTDtAUpLSeYalu0dvaTjS8UaNYRbgXO9evV83UYgGQIaIMRUF2Tjxo1m9erVdtoDnXjat2/v92YhpKpXr27mz59v6tata/NmXNXpOnXqmIYNG1K0EYFGlxMQYspv2Hfffe2cTr179ybfAaXSvHlzG8zoeFKwrJYaLdNxRTCDoKOFBggxlwSsriZdUXPSQWkTgdUao5sKN6qFRkO31aWpEU66abQTEEQENEDIqStAlixZ4vemoAzRSDkN3W7UqJHNn1Fwo1YbTYCqIBoIGgIaIMTUMuMSgTUNgoqeadTTrFmzbD0aIButNjVr1rS3nTt3Mps7AoscGiDEXOKmCulphIoowNFMyQpsgGxS1xOF9RBUBDRAGbiCVsVgupwAFDICGiCk1CrTtm1be9XctGlTs2zZMjtkm8RgAIWIgAYIcdJmu3btbACjgEZdTh06dGAeJwAFiYAGOXfnnXeanj172gqkqmdx/PHH26RVLw0RHTFihK1CquJeJ554op0UD+lRQKOkYCBbVGBP1acjkYjfmwKkhYAGOTdx4kQbrHzxxRfm/ffft4msAwcONFu2bImuc/nll5u33nrLvPbaa3Z9tTb87ne/83W7w0JJwCqGphwaFUTTEFumQEBpqd6MguSZM2fa7kxddABBxrBt5Nz48eNjHj/77LO2peabb74x/fv3t1eBTz31lHnxxRfN4Ycfbtd55plnTKdOnWwQpAq4SE4TBs6bN8/s3r3bfPzxxzawUV4NUNpWv/r165u5c+faiw8dZ5rLSUX3VB7AO98TEAS00CDvFMCIWhVEgY1abQYMGBBdp2PHjqZFixZm8uTJCV9DQ5I1h5H3VqjUTbd161bTuXNnc8QRR5ju3bszBQKyQkFL+fLlbfK5biqqp+J66jKmixNBw2Uc8kqtCCNHjjQHHXSQ6dKli122fPlym9iqsurxFXD1XLK8nFtuuaXI8oULF9pcnWxRoKDS79lcP9k66S73PlYgpxyH77//3nTt2tWsX7/ets7oXvtC/89k+/3YJ6meT/RcOsu8j5P9v1COkVSP1T2ZSRK6AmUlnetzqWOsWbNmaf88kGsENMgr5dJMmzbNfPbZZ6V6neuuu85cccUV0cc6sWsSPbXqqKJptuhLP5OKu+msn2yddJd7H6u1S1fQc+bMMZdeeqldrn2hE4/2hU462a4YnO19kur5RM+ls8z7ONn/C+UYSfU43ZbNzZs322NJ6+t4c/M9AUFCQIO8ufjii83bb79tPvnkk5grO80VoyRWfWF6W2k0yknPJaKrxEIenqwETZ2UtL8WLVpkS9KrgiuJm8gWHVPKm9G9Rjyp5VOfW92rmCMQNOTQIOfUJaJgZsyYMeajjz4yrVu3jnleOR8aUfHhhx9Gl6mPXl0mffr08WGLg085RG56AwU22n+6cma6A2SLPoNqAVTXr+obqUVHrZ8EMwgqWmiQl24mjWB644037NWdy4vRSAmNmtD9eeedZ7uQlCisL81LLrnEBjOMcCqeAhpVCFZQA2SLAhjVhALCgoAGOff444/b+0MPPTRmuYZmn3POOfb/DzzwgG1hUEE9tTIMGjTIPPbYY75sb5i4SSn79u0bXaYEawU4hdwlh9JT7RnlyahbkzIACAOOUuRcOpVGNYLi0UcftTdktm/VQqOEYO++zHbiKwqPWk5Xr15tc9nUsqrgRi02dDkhqMihAUJMI8Z27dplunXr5vemoIzRSLm99947GsAop015NQpwqESNIKKFBggpnVS+++47mzujqq66mgayScGMuoJVAkCBs0Yirlu3zqxatcoW2YtP8Af8READhJQqtmpqCOU4fP311/ZEA+SyarC6nhTYqLK3ivMBQUJAA4S4S0CTfI4bN85OFaE5d4Bc5Glp0lO1ziiIcRWD4yt7A34joAFCSqOZFNDI1KlTqdyKrFKRRnVjqkVGeTNKEm7cuLEttQAEEUnBQIgpd0Z5DJ9++qnfm4IyRtNpqGtJ1YFVWK9JkyYEMwg0Ahog5FR8kIAG2aZaRgqW1bWkxGAg6OhyAkKuR48e5qWXXrLdAq6rQMNrqUWD0tiyZYu9pUI3J4KEgAYIuQMOOMDe//DDD+bkk0+2w7k1mWCyiT2BdCxZssQmAKdCQIMgIaABQkjTGrjpDerVq2fzHBYvXsx0B8iqNm3a0N2E0CCgAUJIV85K1HS6du1qRzoVd0UNAGUVoTdQBiig+eWXX8yiRYv83hQA8AUBDVAGdOnSxd5PmDDB700BAF8Q0ABlgLqaOnfubN577z2zadMmJg9EqWnItuZyUqXgnTt3+r05QLHIoQHKyLxOKnz2ySefmAMPPNBUrMhHG6VTtWpVWwpA0x7s3r3bJgfXrVvXNGzYMDoDNxAktNAAZYDm1hk0aJAd6aR5nfQYKA3NqL19+3az995722BGI562bdtmg2cgiAhogDIyr9NBBx1kuweUGKzHQGloMkq1+qkUgFpk1K3ZvHlzs2HDBr83DUiIgAYoIzSMu1q1ambatGl+bwrKAOXNVKpUKWZZhQoV7GSVQBAR0ABlhCYS7NSpk/nxxx+jUyDMnTvX3gOZUvDikoHV8qc8GuXUKLcGCCICGqCMUL6DKgb/9NNP0cfz5s2z90CmqlevHjOX0/Tp083WrVttNxQQRAyFAMqQdu3ambFjx5LngFJr2rRp9P+tWrWy3U/xXVBAkBDQACGnBGA3r5MCGtFoFOZ1QrbQzYQwIKABQk6jT1q2bGlbZVQjpHbt2mbZsmXM64RSSTe53FWpBvxGQAOUIRpeq4rBU6ZM8XtTEHJt27aNeawEYdWmqVWrFi02CCQCGqAM0ZQH6n565513bIsNUyCgpBK18GmZEs1VMRgIGkY5AWWIqriqsJ5qhUyaNMmsWbPG701CGWsBVHkAIIhooQHKEE15sGDBAjNw4EDTt29fs27dOr83CSG1evXqmMeqQ7Nx40ZbvBEIIgIaoAxR3ZA5c+aYUaNG2VwHpkBASWnWdi/N51SzZk1Tr14937YJSIWABihDpk6dau8HDBjg96Yg5Fq3bu33JgAZIaABypDvv//e1qJp1KgRxfVQKqkSymn5QxAR0ABlhObbUUAzePBgvzcFZcDs2bOTPkftGQQRAQ1QRsyaNcuOaurTp4/fm4IyQBOdeml0k0bR1ahRw7dtAlJh2DZQRnz66ad2rp3evXvbx5r6QHkQTIGAks627b2pBo3md1JxPSCICGiAMuLjjz82Bx98sKlTp459rBPQ3nvvzRQIyGodGg3fVvcmEDQENEAZSeBUQHPkkUf6vSkoQyUA4m+a9LR58+Y2sAGChhwaoAz44osv7AmHgAbZsnDhwpjHqj7t6tFovjAgaAhogDLg/ffftwXP9t9/fzv1AZDtpGB1NSkpWHlaQBDR5QSUAe+9954tpqerZyAXdGw1bNiQpGAEFt9+QMipgN7XX39NdxNyTt2aJAQjqOhyAkJOs2qrO4CABtmua+SlY0x5NKpCDQQRAQ2iNIJhypQpZvHixXam3apVq5oGDRqYfffd1w7/RXDrz7Rv3960aNHC701BGdK4ceOYxzt37rQTVlJYD0FFQFPgFMS8/PLL5tlnn7UjZfSlJWpW9g7N1JfbCSecYC644AIb4CA4PvvsM3Psscf6vRkoYzSzdjwFMxr9xAUOgoiApoDrljz44IPmrrvuMuvXr7etMaow26NHD5v4V7duXRvsrF271jY9f/nll+bRRx81jz32mDn88MPNX//6V7Pffvv5/TYK3ty5c+0JZuDAgX5vCgokMXj79u1+bwaQEAFNgVIXxZIlS8yQIUPMWWedZSc0LG445i+//GKef/5589xzz5nu3bubJ5980gwfPjxv24zEw7VVlv7QQw/1e1NQxmiIdnwOjbqcqlev7ts2AakQ0BQolci/6aabTLt27dL+mTZt2phRo0aZG264wXZRIRgBjWrPJOoeAErj119/LdI6o2k11HoLBBEBTYFSS0tJqUXgvPPOy+r2IHMacfLRRx+Zc845x+9NQRlEkjnChjo0QEip9ozyn9TaBmSbupjWrFljjzFqzyAMaKEBQtzdpK4mkrORCyrfoARgBTa612CBdevWmc2bN9sJKoGgIaBB1Lx588xDDz1kfvjhB7N06VLz22+/FVlHQ7k1sgbBmO5AI84qVuRjjOxT4NKhQwdbymHBggU2oFEAvWLFCr83DUiIb0JY48ePN8cff7wdzq3RTnvttVfCEyVNz8Gg0SaTJ0+2ASiQC0oC1gXMHnvsEa1PpWVqsQGCiIAG1jXXXGOTfV955RVz4oknMslhwE2cONGeZJjuALlSv359WzFcFzeOcmoU4ABBREADa/bs2bYezcknn+z3piDN/JmWLVuatm3b2sJ6QLYpeFHQrHu1ysyYMcMuJ38GQUVAA0sTzlWpUsXvzUAGAY1aZ7zTUwC5nMtJXdD6jqD1FkHFkQnrjDPOMOPGjStSTAvBs2zZMnu1zHQHyCUlAHtvmh6FYAZBxtEJ6+abbzYdO3Y0gwYNMp9//rkd4YDgzq6tlhmNcAJyRUO0k92AIKLLCZZGNl166aXmtNNOM/3790+6nk6kbsQD/JtdW3Np1atXz+9NQRmm3Bkvfe5VnVpJwZoCAQgaAhpYGt105pln2uQ/zdmk/nPqmwSP/j5qQbvgggv83hSUcUo4j6dRTwzbRlBxxoJ16623mlq1atl6ND179vR7c5DE1KlT7ZUzw7XhB7UKzpw5M2YoNxAU5NAgWiVY3U0EM8Ef3bTnnnuavn37+r0pKEBbt25lZB0CixYaRGtLqH8cwQ9oDjzwQIqbIefmzJkT81hdTZoORVMgAEFECw2s888/37z11ltm7dq1fm8Kkti2bZv55JNPTL9+/fzeFBRI95L3plpV7dq1sxWEgSCihQbWSSedZJNNDzroIHPDDTfYGZxVeyKRFi1a5H378L/RTZr1+OCDD/Z7U1AAGMmEsCGggaWRTeob1+STQ4cOTboew7b97W7S6LP27dv7vSkoACtXrkz6HEnBCCICGlgKYkj2C35AM2DAAP5OyIv4quHKn9Gy6tWr+7ZNQCoENLCeffbZvP2uu+66y1x33XXmsssuMw8++KBdpi/KK6+80rz88su2W0UVix977DESED1Xy99//73dR0A+JOpa3rBhg9myZYsv2wMUh6Rg5NVXX31l/v73v5uuXbvGLL/88sttUvJrr71mJk6caJYuXWp+97vf+badQfPhhx/ae7XQAH5RXt369ev93gwgIQIaWNOnTzcPP/ywWbVqVdIWAj2vSRFLSvNDqRrxk08+GZNwqKu+p556ytx///12fiKV9X/mmWfMpEmTzBdffFHi31eWvPfee2bfffe1I00AvyiYqVChgt+bASREQINoN9Ddd9+ddH4gLb/33nvNPffcU+LfMWLECDN48OAirQzffPON7Z/3LtdEmWrynjx5csLXUrfUxo0bY25lhbrfZs2aFc1hUKK28mcOO+ywmOVALuniRRc67vbTTz/Zmd4JqhFU5NAgOoPzEUccYcqXTxzj6qpMz6sOSkkoN+bbb7+1XU7xli9fbipXrmxq164ds1z5M3oukTvvvNPccsstRZYvXLjQ1KhRw2SzMuqCBQuyun6yddxyBWdTpkwxO3bssE3806ZNM0uWLLFBnoZuq6XG+/Pxr+d9nOn2Z+s9ZrJ+qucTPZfOsmT7IAz7I9U66S5P9/GmTZvSzqHRd4MKOib7jgD8RkADS4GDqgWn0rRpU3uFlqlFixbZBGC1MlSpUsVkg5KKr7jiiuhjBQHafn0JJ6ufUxL60m/ZsmVW10+2jluuLrj58+fb96L5tdT9poDv+OOPN19//bWd+sD78/Gv532c6fZn6z1msn6q5xM9l86yZPsgDPsj1TrpLk/3caqWzWrVqqX1foCgINRG9MsrVd0J0fMlCUjUpaSfPeCAA+wM3rop8Vc5Ofq/WmLUGhGfbLhixYqkzdu6UlTg4r2VVWqVUXXgqlWr+r0pABBYBDSwFGyMHTs26QiGdevWmTFjxtj1MqWuqh9//NEOO3a3Hj162ARh9/9KlSpFR/KIckXUfdSnTx9TyBToKY+I2bUBIDUCGkQTdtesWWMTT+PzZNSaouUKai6++OKMX1s5LV26dIm5qUVIicb6v7pVzjvvPNuFNGHCBNuiM3z4cBvM9O7d2xQyjfJSvgMBDQCkRg4NrCFDhthaMA888IANXtSlo+4e5dZoRJFG2vzpT3+yeRy5oN+rZMMTTzwxprBeIbfMKJfmnXfescnSmppCj7Uc8JOmPlFXMRA0HJWIuu+++2wwo0BCo5EWL15sT6aqDaMWnKOPPjprv+vjjz+OeazcnEcffdTe8L98JdXhmTp1qm3BUh6NKrSqlYy5nJDvAEbHnrspqN5nn3383iygCAIaxDjmmGPsDf7S5H89e/a0I8OUS9S/f3/bQpNo2DuQCxrRqABGLaa64FA3sVptGf2EoCKgAQJIw7TVMqN71QDS/91yIB/Wrl1rJ0KtX7++HUWooIaJURFkJAUXKF31l5aKvSG3lLsE+KFTp07R4nqaW23mzJn2e0ODB4AgIqApUO3atbN5MfPmzcvo5zRFwUsvvWT70DX/EnKPq2L4QUn61atXt3WiWrVqZbubNO1GSYprAvlAl1OB0rxNt912m3niiSds0baTTjrJDpHu1q2brQnjpeTgL7/80uZzvP766zYxVaOQzjjjDN+2H0BuaVoE5dBoUlklBit3Rt1P5NAgqAhoCtTIkSPNOeecY2e4VkuLpiZQS4CuyjSySTddjakf3U2GqOcVyFx55ZV25BNyjy4n+EXTI+j7QPWidGOoNoKOI7SAKWi59dZbzahRo8y4ceNspV4NFVaLjOZf0pxBmr9JkyEecsghtlZNtufBQVGqAaSh2bpPtBzIB33WXQvN6tWr7fGn1hndyvJUIwgvAhrYUTQM1w4OjSbp0KFDkRwatzzbs0UDySp8u5nrd+3aFa1DoznWCGgQRAQ0AIBiL3rK+iSwCD8CGiDAyKGBX5T8n0ydOnXsvSazVdc1EAQENACAIlLVm3EBjQYNENAgKAhoAABFtG3btth1NGkqEBQU1gMCjC4nBE02qowDuUALDQCgiI0bN5pVq1bZonrx1cJnzZpl/+8djQf4jYAGCDimPoAfNMWBCurFT4iqGlWNGzf2bbuAZAhogACjywl+2b17t53qIFGAzfBtBBEBDWJMmTLFfPXVV3Y4poppJfoyu/HGG33ZNgD5U6tWrYTLGdWEoCKgQXT45fHHH28+//zzlK0CBDRAYWjSpElGywG/EdDAuuKKK8xnn31mDj30UDNs2DDTrFkzJqMLCHJo4Idp06altV6XLl1yvi1AOjhjwXr77bdNr1697ASVnECDgxwaBKUOjUY7adSTuqKqVq3q23YByRDQwNq2bZvp378/wQyA6GSoiZbNmzfP1K1b15dtAlKhsB6sbt26mfnz5/u9GQACTBc8qkMDBBEtNLBGjRpljjvuOPPFF1+Y3r17+7058HQ50WoGP6xevbrIMG4V26tWrZpv2wSkQkBToEaPHl1k2eDBg80hhxxizjzzTHPAAQckrTUxdOjQPGwhAD9t2rQp5nH58uXtd4KK7QFBREBToM4555wiV/4uAfXZZ5+1t0TPaxkBDVD2tW7d2u9NADJCQFOgnnnmGb83AQCArCGgKVCqNYPgI4cGANLDKCdEc2qmTp1abKGtRLk3AAD4jYAG0ZyasWPHplznjTfeMMOHD8/bNgEAkC4CGqRNk1VqpANy69dffzWzZs2y994uJ+9yINfWrVuXcIJa2bp1q9m+fXvetwlIhbMT0vbdd99RITQPdKKYPXt2kROGW75jxw7ftg2FY8mSJbbYZqKgRkH1ihUrfNkuIBmSggvY4YcfHvNYQ7U//vjjIuvpC23x4sX2y+2UU07J4xYC8ItaY/fYYw/7uW/VqpWpUKFC9DnVo1m5cqWv2wfEI6ApYN7gRd0a+uJKNP2BvtjUMnPyySebBx98MM9bCcAvTZs2NUuXLi0S1OieiVMRNHQ5FTCVMnc3fTndfPPNMcvcTbPs6mrs5ZdfNg0bNvR7swsKw7bhJx17Cmr23HNP88svv0Tzt5Rfo9YbIEhooYE1YcIEewUGAPGaNGliL2rmzp1rW2wVaPN9gaAhoIGlOZy8dDW2YcMGU6tWLdOmTRvftqtQKfFX+1/3aiHT/91jIF9BjNdee+1lu57VSlOlShVTsSKnDwQLXU6I0gnzsssuM3Xq1DHt2rUzPXr0sPd6PHLkSPs88kNXw5MmTbIjSTRJ4CeffGIfk4iJfKldu3aRZQpiqlevTjCDQCKggaUTZa9evcwjjzxi+83VYqMRTbrX44cfftg+zwk1P3Q13LdvX9OsWTObv9C/f3/7WMsBv6nLiaRgBA0BDazrrrvO/Pzzz+baa681ixYtMh999JF56aWX7L0eX3PNNfb566+/3u9NLQiVK1e23X3VqlWzidn6v25aDuSDijjq2Etk7dq19nsBCBLaDWG99dZbti7NHXfcUeQ5nVTvvPNO8+WXX5o333zTl+0rVJUqVbI5NEC+/fbbb0mfUw7N6tWr87o9QHEIaGBt2bLF9O7dO+U6ffr0MVOmTMnbNuF/LTWpTixALqlVNhmOSwQNAQ2sLl26JCyq56XntR7y20LDiQN+adSoEXWQEBoENLCUG3PqqafaWbcHDBhQ5Pn33nvPvP766/aG/KHLCX6qUaMGE9IiNAhoYGlI9sCBA82gQYPMkUceafr162erAmvY8Keffmo++OADc8wxx9gKoaNHj4752aFDh/q23WWRKrC2b9/e3nu7nNxyIB9UIZgq1QgTAhpYapnRl5eGYqo1RrdEicNvv/12kbL8BDTZpYTLDh06FOlycssXLFjg8xaiEKj+FBAmBDSwnnnmGb83AQnQ5QQ/7dq1y2zcuNFWB9YQbnU/KbDWbNve2beBICCggTVs2DC/NwEJMMoJftm6dattDVRQrSBGwYwCHA3XXr58uWnRooUt6QAEBQENEGCMcoJfli5dakc5Jep6Ui7dsmXLTNu2bX3ZNiAR0tcRY8yYMXbKg65du8Z8Wc2cOdPcc889ZsmSJb5uXyEGNMpV0pUxkE/bt29POJ+TaLmeB4KEFhpY6h8//fTTo8OyNX/Qtm3bos/rKu3Pf/6zPbFqmgTkh5vqQK005CwgnzSqTi0xmmE7npbreSBIaKGB9cADD5jXXnvNXHjhhfbL6qqrrop5XkO4Dz74YPPOO+/4to2F2kIjO3bs8HtTUGCaNGliyzaoWrDmbVIXlO71WMv1PBAktNDAevbZZ03Pnj3NY489Zh8nqj+hLigCGn8CGvJokG9Vq1a1dY+8o5wqVqxo6tevzygnBBIBDaw5c+aYESNGpFynXr16Zs2aNXnbJsR2OQH5pqCFejQICwIaRHNmVC04FQ3hTJYkiNygywl+TlhbHIZtI0gIaGDtv//+5t1337VNy6o5EW/t2rVm/Pjxpn///r5sX6Giywl+WbhwYcxjDQjwdjPpMZPVIkhICoZ16aWXmsWLF5sTTzzR3nvNnTvXnHDCCbYFR+shf+hygl86deoUc1Mw433MpJUIGlpoYA0ZMsRcc8015u677zYtW7aMNiXvtddeNm9GtVBuvPFGc/jhh/u9qQWFLicASA8hNqLuvPNO2+2kWbU1wkFXZBrZcNRRR5lx48aZW265xe9NLDi00CAoNMLJ1aZS1zSjnBA0tNAgxpFHHmlvCAZyaBAUtWrVMvPnz7ett5rnidFPCBoCGiDACGgQFOp+1vGo1hn9P1EFYcBPBDSwNEfT2LFjzVdffWVn05UGDRrYYntKCG7cuLHfm1jQXU7k0CAIaJVBkBHQwIwaNcpOPKmTppJ/vUaPHm2nQdD8TUoKRn7RQgO/zJo1K631OnTokPNtAdJBQFPgNOGkkoE10dxZZ51lDj300OgcLZq7ZcKECXaOp5tvvtnWndA98oeABn5Rl5KbnFLHoY5BjXhUK02iWlWA3whoCtgvv/xiW2Zat25tRzFp3pZ4w4cPNzfccIMZNGiQueOOO8ywYcPs+sgPupzgF9WdUgkH76zaNWrUsBNUKocGCBqGbRew5557zg7Lfv755xMGM46e+9e//mV27txpu6CQP7TQwC8Kot3x5+gxwTWCioCmgH3++ee2dHnfvn2LXfeggw4y++67r/n0009LnHSsLi1NcKl5o/RaX3/9dfR55e7cdNNNNvlYzw8YMMD8/PPPptAR0MAvqkWlbmddyIju9VjLgSAioClgM2bMML169Up7fa07c+bMjH+P+uEVEOnkrK6t6dOnm/vuuy9mxIS6vh5++GHzxBNPmC+//NLWulA3l4aIFjIqBcMvTZs2tYG0PvM//fSTvddjLQeCiByaArZ+/fqM+sK1rn4mU5pOoXnz5uaZZ56JLvPm4ah15sEHH7S5OpqCQdS11bBhQzuU/LTTTivymtu3b7c3Z+PGjaYsUSCn2c2Vw6CKrDqRuGVAvoJpfU517Ommx/FdUECQENAUMJUx9yb8pZOg6kqfZ+LNN9+0rS0nn3yymThxor3C++Mf/2jOP/98+/y8efPM8uXLbTeTtyrpgQceaCZPnpwwoNHIrERTMWiGYCUuZosqomYSRKSzfrJ1vMsVoE2ZMsW2zKjk/IoVK2wXnJapu8778/Gv532c6fb7sU9SPZ/ouXSWJdsHYdgfqdZJd3m6jzdt2pR0G3S8qRW1du3adDMhFAhokJfRVI8//ri54oorzPXXX2+L92nWbgVIGjWlYEbUIuOlx+65eKqLo9dzFACoFahFixamZs2aWdt210qSzfWTreNdrhEmKjOv96P9VL16dft/LVOOkffn41/P+zjT7fdjn6R6PtFz6SxLtg/CsD9SrZPu8nQfp2rZ1EWFimwqmNZFgoIbHYflypVL630C+UZAU+A0eumLL75Ia905c+aU6HdoJFWPHj3ssG/Zf//9zbRp02y+jAKaklDLUiatS2GmFhqSgpFv6mJWEOOS89X6qe5PLdPNlRQAgoKApsApSMkkUCnJ1ZlGLnXu3DlmWadOncy///1v+/9GjRrZe10JeqdY0ONu3bqZQkdAA7/o816+fHnbOqjCmsqhU5L/qlWrbOI+NakQJAQ0BUy5K/mgEU7xZdRnz54dbQLXl6KCmg8//DAawKgpXKOdLrroIlPodCXMKCf4Ta0z6npSYKMAW3k4QJAQ0BSwbOcSJHP55ZfbWjfqcjrllFNsYus//vEPe3NXgSNHjjS33XabadeunQ1wNG+UpmA4/vjjTaFSEKNcGl0hb9682f6fwAb5plGIa9euta0zCmI07YG6o5QsDAQJAQ1yTjN2jxkzxiby3nrrrTZg0TDtM888M7rO1VdfbbZs2WIuuOAC+8XZr18/M378+IKeM2blypVm0qRJ9oSiFi39X839qao6A9miMgFKClaLjLp/lSTsCl8CQURAg7w45phj7C0ZtdIo2NEN/6OrYAWDOolo2KxauTRCDMgH5dYpT6ZZs2Z25KBaCoEgI6ABApw7o6vi+vXr25wi/Z+RJcgXtQRyvCFMCGiAgFOuAvNaIR/UvelaTFUVWLkzyt3SPE4abaegWkO2qUWDIKINEQhBQLNmzRq/NwMFUgTTVQ9WDpdyaDSySd2futdwbS0HgogWGiDgdEWsK2Ug1zQ/mps6RMdcmzZtYgpY6jmVe4iv6g0EAS00QAhaaFyzP5BL6kpSZW/3//jJKJmcEkFGQAMEkK6KlZSpe1fvQzVASNRELmk03ZIlS2zhvAYNGphly5ZFA2nd67GWA0FElxMQQKq/06FDB/t/F9CoTk/Hjh2zPls04KhEwOLFi21lbw3TVmuNah+ptcYlDGt5vXr1/N5UoAgCGiAEOTRCHg1yTa1/yptRC41uLogBwoCABgg4DZUVRjohX5QrQ74MwoaABgg41+VECw3yTQUdddyptUatN3Xr1o2OggKChqRgIOB0IqlevTotNMgrjaxbvny5nfZAAY2OwaVLl9q51oAgIqABQkBJmAQ0yCcV0WvevLltlVFSsI7BFi1a2GJ7QBAR0AAhoJMJXU7IJ7XKxM+srcc7duzwbZuAVAhogBDQVTItNPCryJ4b7aScGm/lYCBICGiAEKCFBvmm1hgVc/TO86Sie6pVAwQRo5yAkLTQqNgZkC9NmjSJ/l/VgTWMWyOcKlSo4Ot2AckQ0AAhQAsN8s1bh4bpDhAGBDRACJBDg3zTFAjFadasWV62BUgHOTRASFpoNJfT9u3b/d4UFAh1LSW6aS6nbdu2UY8GgUMLDRCSFhqh2wn5Ep/8q2BaQYxu6o5q2rSpb9sGJEJAA4SAm91YAY0qtgL5oGHbqhisGbdVf0bTcLRq1Yqh2wgkAhogRC00yqMhoEG+aNi2hmorKbh169a2Ng0QVOTQACFroQHypWrVqqZRo0Zm06ZN5ueff7bTIaiCMBBEtNAAIVCnTh17z0gn5JMSgOvXr29vSgRW19OcOXNs0T0dk7Vq1fJ7E4EoAhogBDS6RPkLBDTIl5UrVxZZVrFiRdv9qSkQFi1aRECDQCGgAUKC4nrIp19//TXpc0oKJjEYQUNAA4QExfWQTy1atPB7E4CMENAAIUELDfJNs2wrd0aJwOpuUpIwI50QVAQ0QIhaaDSEFsgHFdJbsGCB2blzpy2kp6BG92q5obsJQURAA4Qgl0EzbSsB88cff4wu08mmZcuWfm8eyqhly5bZY26vvfayrTJqrVmxYoVdruJ6QNBQhwYIOFVonT17tqlZs2Y0h0ZXz1rG3E7IFXU1qaCe62LSfcOGDe1yIIgIaIAQdTmRQ4N8lgpQMO2lAFrLgSCiywkIUUCjriZdIasmDZDr423+/Pk2Gb1y5co2uFELoYrsAUFEQAOErFqwZjuOnwkZyDYFLhrZ5J1hW9MgEEwjqAhogJBNUKny80A+KHghgEFYENAAIaDmfpe7oFEmGzZsKJLfAGTb5s2b7bHmhmxr1BOzvSOoCGiAkMyrs3jxYvv/GTNm2AJntNQgl5Qvo2HaaqGpVq2aDWoWLlxoRzq52d+BICGgAUJAtUDcSaRz586mb9++5quvvvJ7s1CGrVq1ytabUfDsKLjRpJQENAgihm0DIaBRJu7EomZ/3bQMyBUV0ttzzz1jlunx7t27fdsmIBUCGiAkVIJeypfnY4v8JKGrq1OBjehej11yOhA0dDkBIbFr1y57T2Ez5MOmTZtsIT3l0ri5nBTUaB4nPee0bdvW1+0EHAIaICRcUz8BDfKBPBmEDQENELIuJwIa5LOQIxAWBDRAwCn5t3379mbp0qXRgEbN/lqmeyBXNM2GygO4OjTKn6lSpYrfmwUkRHYhEHA6gXTo0MGWoXcBjVvGyQW5LKq3YMECm4Su/2u27Xnz5tn/A0FEQAOEBF1OyCeNaGrWrJmdv0lBjeYPa9GihS22BwQRAQ0QslFODNtGPmiEkyoEe+mxlgNBxDcjELIWGtf1BOSatwaNbN261ebSAEHENyMQEtShQT4pP+vXX3+NVqjWlAeqP6NuKCCICGiAkKDLCfmknBklArs5nNQyqDnFGFmHoCKgAUKCLifkk3cEXZMmTXzdFiAdfDMCIUELDfJp8eLFaa1HFxSCgoAGCAlyaJBPHGcIGwIaICSoQ4N859AAYULbNRAStNAgnzTCacuWLTHLduzYYTZs2EAtGgQSLTRASBDQIJ9UEbh69erR4nqa1+mXX36xdWjUWti8eXNTo0YNvzcTiCKgAUJCJxENoyUpGPmgAMY7umnNmjV2Bm4t27hxo50agYAGQcI3IxCiFhpaZ5Avu3fvjqkKrO4nF8Donm4nBA0BDRASBDTIJ7UE/vbbb9HcGf3fVQ3WVAiu6B4QFHQ5ASHqciKgQb4of2bp0qW2m0ndTcqlccefuqMqV67s9yYCMWihAULUQkOVYORLo0aNbEuMCuzpvmnTpjHPaxoEIEj4dgRCghYa5JOC51atWiV8zo18AoKEgAYICXJo4EdisGbYVg6NupiUDMwoOwQVAQ0QEnQ5IZ80imn+/Pk2+VfBzLp168zy5cttqw0zbiOICLWRlxPxjTfeaFq3bm323HNPs/fee5u//OUvtl/e0f9vuukmW25d6wwYMMD8/PPPvm530NDlhHxatmyZqV27tmnfvr0NYnSvxwpqgCAioEHO3X333ebxxx83f/vb38yMGTPs43vuucc88sgj0XX0+OGHHzZPPPGE+fLLL20f/aBBg2z5dfwPXU7IJ41katCgQcwyPd66datv2wSkQkCDnJs0aZIZMmSIGTx4sL3SO+mkk8zAgQPNlClToq0zDz74oLnhhhvsel27djWjR4+2Q0bHjh1rCp2CulmzZtkuAHU5uccEe8i1+Foz1J5BkBHQIOf69u1rPvzwQzN79mz7+IcffjCfffaZOfroo+3jefPm2WZsdTM5tWrVMgceeKCZPHlywtfUyV3l1723skoJmdp3es9qofE+BnJFraTxk1OqdYYRTggqMgyRc9dee60NODp27GhPyOo6uf32282ZZ55pn3d98g0bNoz5OT1O1l9/5513mltuuaXI8oULF2Z1fhl9gS9YsCCr6ydbJ9lyNf1r3pz169fbUSfusd5rzZo1i/yc93Gm2+/HPkn1fKLn0lmWbB+EYX+kWifd5ek+1gimZFq0aFFkmYIZAhoEFQENcu7VV181L7zwgnnxxRfNPvvsY77//nszcuRIO8ndsGHDSvSa1113nbniiiuijxUwafZffQnrJJ8t+tJv2bJlVtdPtk6y5XpvKmKmsvNKmNZNj/Ve1ZIV/3Pex5luvx/7JNXziZ5LZ1myfRCG/ZFqnXSXp/s4VcumWgKToUowgoiABjn3pz/9ybbSnHbaafbxvvvua79Q1cqigEYVSWXFihV2lJOjx926dUv4mho2WmhDR0kKRj65LuJEunTpktdtAdJBQIOcU/N2fDEunZjVfSIazq2gRnk2LoDRlaNGO1100UW+bHMQEdAgnzp16hTzWJNTqqszm126QDYR0CDnjj32WJszoy4SdTl999135v777zfnnntudOSEuqBuu+02065dOxvgqG6NuqSOP/54vzc/ENT8r9wZ7StXuRXIpfjgWY81n9PcuXPthJVA0BDQIOdUb0YByh//+Ed7hadA5cILL7SF9Jyrr77ajqi44IILbPJrv379zPjx402VKlV83fag0H7TMHbto2+++YaKwfCFAmq1rKrUAkO4ETR8KyLn1EStOjO6JaMvx1tvvdXeUJSSgJXsrP3UvXt3W8UVyDd1HWu0IhBEBDRACGhUiaY+UHCo25o1a/zeJJRx06ZNKzYpePr06aZz58553CogOQIaICRUGTi+FD2QK23bti12nTZt2uRlW4B0ENAAIQpoVIMGyId08tfIcUOQENAAIQpoOIEg18nn6eZ0AUFDQAOEBC00yDXvhKcaybR582abv1WpUiVbh0blAqpXr+7rNgLJENAAAacTSvv27aMBjXtcaJWSkXve+ZuWLFliK3fXrVs3umzt2rW2HhIQRMy2DQScupk6dOgQDWjcY7qfkEsbNmwoUkBPj7UcCCICGiAk6HJCPql4o7qcvFSlmqKOCCqOTCAk1NRPqwzyRfOrLVy40FSrVs12cyp/RpWqNas9EEQENEAIqNz89u3baaFB3qgyteZW01QkKupYtWpVO22JghsgiAhogBCNPiGgQT4peIkfoq0q1fXq1fNtm4BkCGiAEHAjSwhokC/qYtKoJrXOeCkp2B2PzZo182nrgKIIaIAQoIUG+ab8GdWfSdTFVKFCBV+2CUiFgAYIAXdFTFIw8kWF9BLN57Ru3TpbnwYIGoZtAyFAlxPyTa0zmSwH/EZAA4QAAQ2CMtu2Rj4BQURAA4QAOTQAkBoBDRACtNAAQGoENEAIkBQMAKkR0AAhQAsNgiASiZiNGzf6vRlAQgzbBkKAgAZ+2rp1q50CQUX1VING0yIAQUNAA4SAkoI1XJaCZshnpWAFMbrt2rXL1KpVy7Rs2dLO6QQEEQENEJIWGlpnkE+zZ8+2M203bNjQtsiUK1fO700CUiKgAUIS0JAQjHxSS4y6mtQqqGCmRo0aBDUINAIaIARooUG+tWnTxnY7aaqD5cuXmyVLlthup9q1a9PthEBilBMQkhwaAhrkmyamVJdT+/btbf6MRjnNnz/f780CEqKFBggBWmjgN7XK6MbElAgqWmiAECCgQb4tXrw4OuWGV/ny5e3Ip02bNvmyXUAyBDRACJAUjHxT0KLupURBjRKFV61a5ct2AckQ0AABpRPJrFmz7L1rodH/586dm/AkA2STWmL22muvhEGNhnNv377dt20DEiGgAQJKJwzVAtFIE5cUrGXz5s3jZIK8qFu3rk0KVlDjqlU7DOFG0JAUDISATiY6sQD5VqdOHRu8KJDWMajWmdWrVzN0G4FDQAOEAEnB8JNqz1SsWNEsW7bM3hTMNG/e3O/NAmIQ0AAhQFIw8q1du3Yxj6tXr26XqRYN3U0IInJogBCgsB7yTZOhJkIwg6AioAECTAnBqvehOXV0ItmwYYNdBuTali1b/N4EICMENECArVy50nzzzTdm4MCBdnLASZMmmTVr1vi9WSgACxYs8HsTgIyQQwMEmOqAqNT80KFD7WO10GiyQCDXOnfu7PcmABkhoAECPjmgWmY0y7F3GQAgFl1OAIAiVHdm8+bNCZ9bu3YtLYUIHAIaAEDCpOBFixYlDGr22GMPG9QAQUJAAwBIOJdTs2bNEgY1bhoOIEgIaAAACSl/SxWBFdSofICj4noKeIAgISkYCCg167dv377IstatW9t7IB9UIVhBzcKFC+28TprLSd1NCnaAICHEBgJKUx106NAhZsoD/X/vvfdmGgTkPahp06aNLeqouZwqVKhgGjVq5PdmATFooQEAFFuHRkF0y5YtfdseoDi00AAAgNAjoAEAAKFHQAMAAEKPgAYAAIQeAQ0AAAg9AhoAABB6DNtGmaDKpbJx48asvq6qo2bymumsn2yddJdn8jjT7fdjn6R6PtFz6SxLtg/CsD/yeYy4Ze7zA4QZAQ3KhDVr1th7VTQFkPnnp1atWn5vBlAqBDQoE+rWrWvvVZ49m1/MPXv2NF999VVW10+2TrrL032sq283D0/NmjVNUPdJqucTPZfOMu/jsO2PfB4jGzZsMC1atIh+foAwI6BBmeAmylMwk82TlUq8Z/J66ayfbJ10l2f6WP8P8j5J9Xyi59JZ5n0ctv3hxzHCRJMoCziKgRRGjBiR9fWTrZPu8kwfB32fpHo+0XPpLPM+Dtv+KAvHCOCHchGywVAGqDtBrTNqQs/m1XeYsU9isT+KYp+gLKGFBmXCHnvsYUaNGmXv8T/sk1jsj6LYJyhLaKEBAAChRwsNAAAIPQIaAAAQegQ0AAAg9AhoAABA6BHQAACA0COgQcFR6ftDDz3UdO7c2XTt2tW89tprptCdcMIJpk6dOuakk04yhertt982HTp0MO3atTP//Oc/TaHjmEDYMGwbBWfZsmVmxYoVplu3bmb58uWme/fuZvbs2aZatWqmUH388cd2BubnnnvOvP7666bQ7Ny50wa4EyZMsIXmdExMmjTJ1KtXzxSqQj8mED600KDgNG7c2AYz0qhRI1O/fn2zdu1aU8jUYlWjRg1TqKZMmWL22Wcf07RpU1O9enVz9NFHm/fee88UskI/JhA+BDQInE8++cQce+yxpkmTJqZcuXJm7NixRdZ59NFHTatWrUyVKlXMgQceaE9IJfHNN9+YXbt22VmYgyqf+yOsSruPli5daoMZR/9fsmSJCSuOGRQiAhoEzpYtW8x+++1nv3ATeeWVV8wVV1xhS7Z/++23dt1BgwaZlStXRtdRC0yXLl2K3HTictQqM3ToUPOPf/zDBFm+9keYZWMflSXsDxQk5dAAQaVDdMyYMTHLevXqFRkxYkT08a5duyJNmjSJ3HnnnWm/7q+//ho5+OCDI6NHj46ESa72h0yYMCFy4oknRsKuJPvo888/jxx//PHR5y+77LLICy+8ECkLSnPMlJVjAoWBFhqEyo4dO2w30YABA6LLypcvbx9Pnjw5rdfQd/w555xjDj/8cHP22WebQt8fZV06+6hXr15m2rRptptp8+bNZty4cbbFoizimEFZRUCDUFm9erXNeWnYsGHMcj3WiKV0fP7557bJXXkF6orR7ccffzSFuj9EJ7OTTz7Z/Pe//zXNmjUrUye2dPZRxYoVzX333WcOO+wwezxceeWVZXaEU7rHTFk+JlA2VfR7A4B869evn9m9e7ffmxEoH3zwgSl0xx13nL3hfzgmEDa00CBUNMS6QoUKto6Mlx5rCHahYX8Uj30Ui/2BsoqABqFSuXJlW/Tsww8/jC5Ta4se9+nTxxQa9kfx2Eex2B8oq+hyQuAoKXPOnDnRx/PmzTPff/+9qVu3rmnRooUdbjps2DDTo0cPm8z54IMP2mGqw4cPN2UR+6N47KNY7A8UJL+HWQHxNFRUh2b8bdiwYdF1HnnkkUiLFi0ilStXtkNQv/jii0hZxf4oHvsoFvsDhYi5nAAAQOiRQwMAAEKPgAYAAIQeAQ0AAAg9AhoAABB6BDQAACD0CGgAAEDoEdAAAIDQI6ABAAChR0ADAABCj4AGQBHz58835cqVK3KrVq2a6dq1q7nlllvsfEHZ8te//tW+/rRp07L2mgAKC1MfAEgY0LRu3drsvffe5qyzzrLL9FWxatUqM27cOPt87969zWeffWYqVKhQ6t938MEHm2XLlsVMqAgAmWC2bQBJtW3b1tx8880xy7Zv32769OljvvjiCzNx4kRz+OGHl+p3KEiaNGmSGTlyZCm3FkAho8sJQEb22GMPc9hhh9n/r169OuY5tdgccsghtmuqXr165tRTTzWLFi0yhx56qO1SSuTtt982u3fvNkOGDIlZrmCpf//+Gb0WgMJFCw2AjOzYscN8/PHHNqjo1q1bdPmHH35ojj76aFO+fHkbfDRp0sQuO+igg0ydOnWSvt7YsWNN/fr17XrOe++9ZwYPHmy7s9xrTZgwwfTr1y/lawEoXAQ0AJJSTovrclIOjVpk3n33XbNkyRJzzz33mPbt29vn1MJywQUXmJ07d5pPPvnEBh7uZ5SD8+KLLyZ8/a1bt5r333/fBi0uF2fXrl32tXTvghhn2LBhZvTo0Xl45wDChqRgAEmTgpM55phjzF/+8pdoC42CGHU1HXvssebNN9+MWXfBggU2uVgBSvzXzRtvvGGOP/54M2bMGHvvuprUrXTcccfZ573U5aTtSvRaAAobOTQAkho0aJANHNxNLTQKMjS8Wl1EX375pV3vhx9+iI5WiteyZUvTvHnzhK+v19pzzz3NwIEDo8vca3lbZhy9TosWLbL2/gCUHXQ5IZR0hf7bb7/5vRllev8qEFFuy6+//hpdrgRdBR9PPfWUOffcc81DDz1knn76advVpPWbNWsWs76j2jUKiLzP6Xd8//33trtJeTfuOfe7U72WurgSPYfsqFSpUlaG4wP5RJcTQkWH6/Lly8369ev93pQyTQGK8mSqVKliGjZsWOR5BRTq/lFisFpMNm7caNatW2dq165tatWqVWR9vZYLehwFJCtWrLAjmKpXrx5dXpLXQvZp/zdq1IgRZQgNWmgQKi6Y2WuvvUzVqlX5ss3hSCbVm1GLTKJcGj2/bds2u//1/JYtW8y8efNsYNKqVasi6+p58b6WCumpNaZDhw62RcBxr1WjRo0iQUuy10J2LxqUrL1y5Ur7uHHjxn5vEpAWAhqEhk5+LpjRVT1yxwWK6nZQK008d7KrWbOmfV61aZYuXWqnQ1BXoIIRd3LUcsf7WlpXAZBb19FrqRVm06ZNtiXG23qjICjRayG7lNfk/s76vNH9hDAgoEFouJwZtcwgP9RK4w1IFGAoENEVvE5yynNxAZBaU37++Wcze/ZsU7duXdvqoqBEfzedINWi4+j/eu0GDRoU+Z3utTRkfNasWcW+FnLDfc60zwloEAYENAgdupn8C2i07ytXrmwDEeVXqDXFUWuN6tKodUU5MEr0VetLmzZt7DBwL5cDpTyNRJQ7065dO/u7va+l4d8KmjjB5h6fM4QNAQ3KNCWeqg6Krvgz6aIo6c+VFQpUevTokfHPKejo2LFjsespoNF+TbVvFSDpFt/tqCDLdYkAgEMdGpRpOvmpC0T3+fi5knr22WeTtlaUNS6xN9H7VUuOWga++eYbG7x4KR9n8eLFdoSV92e1vqZPyAVN3dCpU6ci2xJkSsp+8MEHU67zxBNP2CKIQFlCQAPkwTnnnGNPvK7LRrNY33rrrTYnpTSefPJJW8xO8xvpNmDAADNlypSYdf7zn//Y2jFKpNbvV+2XRC1SI0aMiA6hPvHEE+2Q6lzQ+1frzw033BCtDuwtnKfEX3U3qcCe8mg0PFytZT/99JOdmVutM0pUdbS+5pDyBkSJ3mNJXH311XY7XReXAk/3d9RN+6p79+52H5eURmt98MEHJlu++uorO3VEqoBPNYS+/fZb8+mnn2bt9wJ+I6AB8uSoo46yJ1/lgFx55ZV2jqR77723VK+pSSJPP/10O+fR5MmTbUCg4EV5LI5aQ1R19+677076Opdffrl56623zGuvvWanHlDuyu9+9zuTbwoclJujoEUBmpJ/FcSoQrFaaFQTR8O8vTk08bk82aKZw+fOnWuDOy91g+nvqNt3331nqymfcsopNoE5U1OnTrU5Qpo2IluU31Rc4ryCyjPOOMM8/PDDWfu9gO9UWA8Ig23btkWmT59u79O1fv36yJtvvmnvM1HSn0tm2LBhkSFDhsQsO/LIIyO9e/e2/3/mmWcitWrViowZMybStm3byB577BEZOHBgZOHChRn9np07d0Zq1KgRee6554o8N2/ePBXRjHz33Xcxy/UeK1WqFHnttdeiy2bMmGHXnTx5ctLfNXr06Ej37t0j1atXjzRs2DBy+umnR1asWBGzzrRp0yKDBw+226T1+vXrF5kzZ05k1KhR9vW9twkTJsRs465duyJNmzaNPPbYYzGv+e2330bKlSsXmT9/vn2s9bXf3P+9t0MOOSQyceLESMWKFSPLli2LeZ3LLrvMbk8yI0aMiJx00kkxy9zfyUvbqf336quvRpdpPxxzzDGRKlWqRFq1ahX517/+FWnZsmXkgQceiPnZW2+9NXLqqafa/2uf7LfffjHPa339XPxxdO+990YaNWoUqVu3buSPf/xjZMeOHdF1vL9H//fuD+9rab9Urlw5snXr1qx93gA/0UID+EStEMoncTQU+vbbb7ezSX/++ec2cfa0007L6DX1Ghpmq6HO6VK+in5G3VWOEntVAVitPsnoZzRBpbqG1KWh7h51rTlqJerfv79tPfnoo4/s71FXh7rZrrrqKtuq4VqtdOvbt2/M62tkk1qf4mfqfuGFF+w8UokqBbvuNnXh6DXVFaRt0Eir559/Pmbb9TranmTUHVNcYrRya5577jn7/wMOOCC6XPtBXWVqOXv99dfNY489Fq3d46WJPIcMGWIyoddUy5Hu9bvVDaZbsu4neeaZZ+z+cI9F701/CzcfFxB2jHJC6OkkPnPmzITPqXaJntPJ0VugrTiqtaKfU/dCfOE370m/JDVx1JCgZNN3333XXHLJJTEn2b/97W/mwAMPtI91slJCqk7SvXr1Suu1r7nmGtOkSZOY4CSd6svqgohP0lX3jp5LxhsMKGBQ90XPnj2jBfMeffRRO/z65ZdfjlYC1rBub0CnpGt1GSVz5plnmvvuu88sXLjQBlhKCNbrKa8lEVfXRrlA3tc977zz7En9T3/6k32s7jXlDSmoSkZ5O9qX8TZs2BA9ltQlpvf2j3/8ww4pFyWTjxs3zv7dtD9Ec1/pb+mlgE9dTi7/J13qitNxom43HYODBw+2x9P555+fdH+4aQy8dOzq76P3CZQFBDQIPQUeSszMN7U4eK/Ki/P222/bE6ECF52YlcOgPBqnYsWK0ROg6GSlE9GMGTPsyahz587R566//np787rrrrvsyV55NfkYaq73r+1XC43yQPSeRMGHtlWJuUpY9k5rkKlu3brZQECtNNdee63N71FLx8knn5zR66jFREHQF198YXr37m1bNBTMaGqHZBSsJNqPCnCVUOuCabUG/eEPf7BBlEYO6e+lv6X3mHR/y/jWGeU2ZTq6bZ999onJIdLUBD/++KMpCQWVeg9AWUBAg9DTyUIn12QtNLpS1gk20xaa6dOn25aRVC00mTjssMPM448/bltDdOWvk166tL535E58l9Jf//pXG9Do5KrZqDOhYEldX+ri8p5cNcopWeuJEo2VDKubum7UEqBARo9dN1q2asWolcYFNLpXN1WmU19oVJSCDbXSaFSRWlAU+KWimcYVqMVTa59GqTna3++9955Nus5kKLQCmuOOOy7mdePnCk40o3x8gKhRTC6YzNTatWsTVmsGwoiABqGnpvNkLSXqHtDszboSTjRzczL6OZ0k1EKQyc+lotYA74kwnvIZvv7662j3kkbNKMhQC4WCn2Q/e88999jcG3VhlaQYnloSdJJUt4Ub0aPfrQClT58+SVvF1qxZY4MojawSbbuXTvTqNtNJOVErjQK7dOq7qCVLrSsKWpWPohoqyeg1JdHr/v73v7c5OZquQd1DysNJZf/997dBbTrUYuKmY1Cgq7+ltte1uLm/pTdgVg6MAlxHgYW6+BTUuCq92Rh+rn2faH8oD0fdbnqfQFlAUjAQEDrxKKdGSZo6GaqbRN0jqfJn1Cpw4403mqefftoWVNMJUTedML1X4ToxupOzTq567PJjFLApx+SKK66wJ1n97uHDh9tgRr8/EeWzKHh45JFHzC+//GJbG5Qg7HXxxRfbYFKJzQp2NFxdiblueLO2Vzkkeqxh2YlaI9x6ShjWNurE7G3VSNQSo5ah8ePH2xYmBaaOWo+UE3XbbbfZ91ccra+h2/EUcLj9rFnBlT+jYNIl92pYuVqRLrzwwujfUsGUt8VK26d8Iu/M5Iceeqgdoq4AVcGGcpDUklRa+h0KVrW93hYnJT0r98nl/gBhR0ADBKilSUm9apFQ64G6yF555ZWUP6MrfHXxnHTSSTaXwt3UBeUo2NBVuJJHRQGGHntbOh544AFzzDHH2BYajQpSV1OqYnFqTVAeiurWqDtPLTXe3ynqFtLoJgVXqrOiliAVAnStNUpi1clfrUp6PY3sStXtpFydE044IWVXllqylJz897//3XbTeUcQqUtHQaKCoqFDh6bcr+53qphffH0ZBWluP6v1TEnLKpL45z//ObqOurb0+/W+Vc9Hhe68xQDfeOONIoGZXkujoRTI7LfffrarVKPBSkvb9/7779uWNG9rzEsvvZQwkRgIq3Iau+33RgDpUPO4roiVA5Fu0quu0D/55BN7ks60y6kkP4dgUyuPWkEU5KVDo6IUwChAykZLyciRI23LlUaQqfUl3dFr2aZA7fDDD7cjspId3yX5vAF+ooUGQJmnAFXdR0oq9g6VL45aXVTvpqRJt4moC1CVmb0j2vJNNWlU74hgHWUJScEo01TUTbkKmZbGL+nPIZjU9aQuHA2vPvLII9P+OY36ih8eX1rqekpWRydfMqlTBIQFXU4IDZrAgfzh84awocsJAACEHgENQodGRSD3+JwhbAhoEBpuuC+l2oHcc5+z0kxdAeQTScEIDVVjVZKmm7VYdVtcRVUA2WuZUTCjz5k+b955o4AgIykYoeKqtHrLyAPIPjdDNxcNCAsCGoSSqr0mK5UPoHTUzUTLDMKGgAYAAIQeScEAACD0CGgAAEDoEdAAAIDQI6ABAAChR0ADAABCj4AGAACEHgENAAAwYff/AFDX+zhkFiTDAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 300x500 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "plt.figure(figsize=(3, 5))\n",
     "plt.errorbar(\n",
@@ -719,10 +943,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "id": "b4ae8d39",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Figure saved -> D:\\210Pb_thismachine\\NBP2002_KC72_gamma spec data\\AgeModelPlot_NBP2002KC72_20250904.pdf\n"
+     ]
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "Notes for AgeModelPlot_NBP2002KC72_20250904.pdf (optional):  \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "README created -> D:\\210Pb_thismachine\\NBP2002_KC72_gamma spec data\\AgeModelPlot_NBP2002KC72_20250904_README_20250904.txt\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAe4AAAPkCAYAAABvE90ZAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAA1JBJREFUeJzsnQeUE2Xbhl9RUOmgAtIFQUCkqCgooiKKiL03wI6990YRQfwUFcWGDVRARcGKXSyggIoFkSYgSJHeRQX2P9f7f2++2WySTbLZzczkvs4J2UxmJpOQzD1P3y4vLy/PCCGEECIQlMr2AQghhBAieSTcQgghRICQcAshhBABQsIthBBCBAgJtxBCCBEgJNxCCCFEgJBwCyGEEAFCwi2EEEIECAm3EEIIESAk3EIIIdJi/vz5ZrvttrM3/s4k9evXt/t94YUXMrrfMCDh9jG9e/eO/CjKli1rFi9enNQPaPz48QWeP+ywwyLPe2+lSpUyFStWNK1atTI33nij+f3335M6Hu9tp512MrVr1zbHH3+8efXVV02sLrobNmwwr7zyirnoootMy5YtTYUKFUyZMmVMjRo1zNFHH21/nFu2bCn0M/nnn3/MoEGDTJs2bUylSpVM+fLlzT777GN69epl1q9fX+j2rMP7YBu2ZR/s68EHH7T7jseiRYvM448/bk477TSz5557mp133tne9thjD3PWWWeZTz/91BSF8847z36WnKwScc8990Q+d44l+pi3bt1q/w+6d+9uGjdubCpXrmw/52rVqpn27dub2267zUybNi3u6yd7i/6e/P333+btt982V155pdl///3t65YuXdrstttu5vDDDzePPvqo2bRpk8kkBx54YOR4hg4daoKOEypuVapUMZs3b064/tKlS+1n7LbhNy5yBHqVC3/Sq1cvFDByu+SSS+KuO2/evMh6n332WYHnDz30UPtc6dKl86pXrx65Va1aNd9r7Lzzznnvvfdeocfj3cdOO+2Ubx9dunTJ27x5c75t99xzz3zrlClTJq9ChQr5lrVp0yZv2bJlcd/jqlWr8lq3bh1Zf8cdd8wrW7Zs5HG9evXy5s+fH3d7nqtfv35kfbZlH+4x++Y1olmwYEHedtttl+9Y2ZbPyrvsggsuyNuyZUteOvTo0SPyHmKxbdu2vGuvvTbyWhdffHHe1q1b863z9ddf5zVu3DjfMfH/zf9xqVKl8i0/+eST8/7+++/ItldffXW+/9NYt+23395uu/vuuxd4n506dcq3/x122CGvUqVK+ZbxHZg9e3ZeJvj555/z7btt27Z5QYf/e+97GjFiRML177vvvnzr8xsvabznHf4ujs/j+eefz+h+w4CEO0DCzclw5syZRRLuWD/uv/76K2/UqFF5u+yyi12HE/2GDRsSHo8XBGTatGl5Rx55ZOT5G2+8scCPsFmzZnn/+c9/8n755ZfI8iVLluTdcsstEVE45JBDrEjFggsC1qlYsWLeK6+8EhGuDz/80IoJz+2zzz4xxfPff/+1zznh+eijjyLHznt3FxHHHHNM3M/2iCOOyBs2bFjeokWLItvyXk444YTI+77zzjvzMi3cvJ/zzjsv8ho333xzgXXeeuutyEUI/48DBgzImzVrVr59TJkyJe/WW2+1nx/rrV69OunjW7p0qf3+sR37iIbvFcfeu3fvvO+//z7yf8OF0MCBAyMXWIg337ei4i5i+Fzc/533exVEnFC5i0t+T4lo0qRJvvUl3LmDhNvHOKGsU6dOXosWLezfp5xySsaF2/Hiiy9G9hHL6o4n3A5OyM6y5mSKWDo4pniCDAiN2/eXX35Z4PmPP/448vzIkSMLPD9x4sTI888880yB51nmnmfdaLBu3PO8lpc1a9bkfffdd3GPnfd19NFH223Lly+fljDFE248FyeddFLk2BDBaBBoJ8ZcHC1cuDDha61cudJebKQi3M66w/MQy2rm/8z7/x0N/2fuPfA9Kwp4CnbddVe7r2+++SZyUXP99dfnBRknVDfccENeuXLlrJfk999/j7nuhAkT7Lp77LFHXvfu3SXcOYZi3AGAOPSAAQPs36+//rqZPHlysbwOcW5vTDpViHUTd3Wx5BkzZhSIscfjwgsvjPw9ZcqUAs8PGzbM3jdo0MCcccYZBZ5v165dJMY3fPjwuNsTb2XdaM4880wbr461PXHwfffdN+6x874uuOCCyOf266+/mkzAvrp27WrGjBljtt9+exvHvfnmmwusd+edd5p169bZz591yTdIRNWqVc3YsWPt+0qW5557zt4feuihNsYfDfHzHXbYIe72p59+us1riPf/mwpvvvmmWbFihdlrr71snLtHjx52+UsvvWT+/fffQrf/+eef7XeI/Ao+M75TV111lVm2bJnND3Ex43jw3b7vvvvs94jPcscddzR16tSx36Gvv/7aFBVyL/gdbdu2LfK9jff/4XITCuO3334zl112mWnUqJHNzSCvhe9037597XcnEeR39OzZ075H3ivfr/PPP9/MmTMnqfdDHgb5Ifz2dt1110huywknnGDGjRuX1D5EFNm+chDxcRaus8Kc1Xz44YcXi8X90ksvRfbx448/xj2eRF+bIUOGRNbBKkiWdevWRbbDnR5NjRo17HOXX3553H1gjbIOlsqmTZsiyzdu3BiJ8d5///1xt7/sssvsOrxWquCqdsePS7qoFjdW8QEHHBDJBxg9enRcF7Z7bxdeeGFecfDFF19E3hvfkXRx+RRXXHFFkY6nc+fOdj/33ntvxOPhrLPXX3894bZvvPGGjfu794OHxOVoEELBukv0HZ86dWpe7dq1I+sQ4vHmauCR6N+/f1rvy70Hfmeff/65/btBgwYFPFV8n3lN/t/J23DfnXi/bcJK3lwOtvU+xqM3ffr0mNviaapSpUpkXfI6+My8IatEFjfHt/fee+f7fKJzHy699NKEn4cs7oLI4g4QXOXDZ599Zt5///2M7ZeM4NGjR5vrrrvOPj7qqKNMixYt0tqXtyQEayRZvJnwZHx7Wblypc2ghebNm8fdh3sOS8Vr9fI3y5LdntdatWpV0sfuPX6sCbK5iwLVAx06dLCelXLlypl3333XnHLKKTHX5bvg3ttJJ51kioNnnnnG3pPpHO84krFy3Wca/f+bCgsXLjQfffSRtTLPPfdcu4y/yaKHZ599Nu62c+fOtdtglWNtfvvtt9Z6JtudffJ/d/3118fdfsmSJaZz587mjz/+MCeffLLd/q+//rIW659//mnuuusu6xm5/fbbrUejKPD/j2eDY/7888/zPffaa6/Z4+7YsaOpV69ewv18//339j3zGz/44IPNTz/9ZI+X9/zWW2+Z3Xff3X6mxx13XAEvG6/Bd2r16tWmbt265sMPPzQbN260yydOnGgtcCzxeLAuFSO//PKL9YbxG+HzWrNmjb1RHYJ34cknnzSPPPJIkT6vnCOGmAufWtzg4p2tWrXKdyWeiaxyrrxJfPJaq7GOJ97XZu3atXk1a9aMJLhFZz3H459//onE8Bs2bGgfe/npp58ir/vmm2/G3c8PP/wQWe/tt9+OaQ3H8iQ4xo4dG1mPrOVkmTt3biT5qlu3bnnp4KwmrBvilu4zJIabCJLh3DG7pLlMwv+pe29XXnll2vtxiYWVK1e23oR06dOnj91Px44d8y0n7u4s4HifAx4J1qlWrVrMY5gxY0Y+SzQaqgZYfvbZZ8c9vkGDBtl1WrZsWSSLG/r162cfE8P20qFDB7v85Zdfto8TWdwu94LcEyz1aEgkdEmH0Z4u58HC4xPLIiex1GuNR1vcffv2jRxX9G/a6wFhHXIWonMkZHHHRxZ3wOjfv7+9qv/hhx/MyJEjU94eawPrwN28luXatWvtY+5TgavnTz75xFoArtb8mmuusbH5ZGBdLAEsp8cee8zWpnrx1mdTzx4P73PebYq6fSKwIIhHYsEQv3NekXTBupk3b579m5prYriJwBuRjocjWUaMGBGpv/bmIaTC/fffH4llDhw4MO3jJJn2+eeft387C9uBdXrQQQfZOvZYDTvYlvwQINYb6xiImROLjwU11XwWcMstt8Q9RndcP/74o/19FQVi9/yG8Ia57yOx6i+//NLWyWP1F/a7/OCDD+zfN910U8zvfuvWrSP7iT6fjBo1yt7z/W7atGmBbYlTX3rppXFf33k/8GJE/6YdJ554oo23k7Pw3XffJXw/4n9IuANGkyZNbGII4JpLJhnHC8lF/60miNwQ6o8//ti6x3GLHnDAAWb27NkJ9+NtxoELtVOnTpEfHq65O+64I6njofHJE088EXk/uNaCAg1jzj77bPu+OTG9/PLLpmbNmkXa5y677BJxteNyfeONN0w2cSff/fbbL1/yYrLQDIYLECdql1xySdrHQpMbQjGED2K57F2SmhN3L7icETL3G4hHvCYm/B+7hiiEkhCtWLe99947sk2iZkbJQBLYkUceaS+caF7k3hu/WRLhSKwrzE3umiHx+4wHrwFcPLvzCQllhDeAC/J4xHuOhDb3/rngi/d54ap3Lvqifl65hIQ7gND5i8xQTkbEh4oKV7xHHHGEee+992zMjJhXotgVVK9ePXIj/kXMkB8oJ9cXX3zRegUKg25adGuDa6+91vTp0yfmei4bGRJ13/I+592mqNvHAsvunHPOsbFMsqmxxjihFxVifsQCsf44iZL9jMWVSOgdqcblC4MTOXFcoONdqpDhzmdEDB6hTRR/Tga3PXFXPqdosJYRM7Kdo+PCy5cvj/yd6OKqVq1aMZd7uxZ6PVaxbo5MdIpz1QoINp+jq3hwyxNBlnxh7wtcFQIXou47xL3rZJjMtok+L6zpRJ+Xy9HIdGe9MCPhDiD8kChfgX79+qVVuhULxMqVWpH0RDJOPEjgcjeulLFIsNYp+UgGXOJXX321/Zs2mQ899FDcdb0nWq7k4+F9zrtNUbePJdp4FbAmuUChDOnUU081mQIrBPHGPcnJk5aqvFYsvBbe1KlTTXEkpeFixbOQClzQ8F3i+BFa3K6JysWSCSFwIQB83rHasHrbhCa6SEimfCrW/7k3PBLttYp1y0QLUkqmeF8kgw0ZMsReVPN/TpteP+P9vEgOTebzorRNJIeEO6Dceuut9gfNVTXu5kzhzVLN9NAAr6XtLjyuuOIK+zgRWJW41SBWn22He464oDcmx98u3p7M9rxWvDiss7QRIifaserKiwrHwMVTs2bNIi555y71woWSe29O2DIBWci4/l2ME69MsnAcWL94DIhhctxFEW3gWArr3e0FL4W3Ppme6Y5EPf/jXdi5719Ju3Spm3YXTc475UJlhUF/egeZ8PFwz/F/5L733DuvWbIXu374vHIFCXdAQbQRb0C4va7AouD9gRNLzDSItNfSxvJOBheHI9km1hATcCVyNAMhlODAYqQUxrtONOzTJfLEc3kj2k5AnWgTaywuCEMg3lhY7oIhOoGIdVy8F3f9rFmzkt5/vM8RiK07t2kqSWlsx4WME208BfESk1LBWdAkMpKoFe9GvgYijVXs/axoskJCF8QawuOI9xwWLuViwDCVksS5xYk7I67dunVLajvCV+6ijuTReJDfAgz/cf9XvFdXEsp3MB7xhuswMMW52Ev688oJEmScCx+Wg3mhbMs1gzjuuOOK3ICFVp177bVXpDFF9KCQZBqwJGLw4MGR7a+66qqUtvW2PKXpQzSUTSXT8pQGELFKrLyNJKJbnrpe32eccYZ9nvIZ+ptnkkS9yhm84vqsU+4U3QSF/vWuKQbNLv7444+Er0X/cIaMJGp5Sl929sf3IVm8zU0oW4xXApQqNAFx/zeFlcdBz549I0NrYpVzUQYZa5gMrWMTlYO51qqULsVrRepIp+QtuhwsugyOVqiPPvpogecSlYO5Mrx45WCUULpysAceeCBmm1s+E0rlovnzzz/zlZNGl4PRt57lNLih7CzVz0vlYPGRcAdYuKN7cBdFuKOHZTD4I97xpCPcjz32WGTba665Ji8d3EmIzkuvvvpqpE4coXX148kMGalVq1ZEnNkH+3K9vnmNaNjfmWeeGRFt1s80hU0HW758eaTWnY5Z0f2+x4wZY+ttnbBw0vX2FOc9cPK86667bC0168UTburS3TS0RJ3momvgnWjTTz9R3/JUoVteYb8DL5988knMenw+DzfRbf/994+ICf0Q2Ib6eW9dcjSLFy+OfM+4Hz58uO34573AosPdiSeemHfUUUdlVLgTkUi4uehx/y/t27e3PRHc9/7dd9+NvB/6J6xfv75ADb8zDBhkwm/G9Y7gAorfk/suxRJu9ud+c/xmuehYsWJF5Hm+f8xEoPcBPfbjfR4S7oJIuAMu3JyQ3ZSgdBqwcPOOxuSGZRnLWiqKcHvHYhY2PpIRk8mM9eRKPpWxnpxYosd6ekeSxhvr6dpPxvv8om/pWOOFCTdw0qOxhxNvJpV5+eqrr2KOT40e68n/xVlnnRXXInZNXXivWFXJ4JrGuAuHRJ8P1niy4AVy4oDFmQz8JmiywjZMEfPy2muvRSxM1/7TfYe4oHMtT7EyY0EjEu/oVD5XPl+Ggng/d8ac+kG4ge+ju6jjxkWq93ufqOUp7Xu94sxn5bw7fHaFtTylGQ4jV73fPfbnLpTdje9tvM9Dwl0QCXfAhdvbfSgZ4Y5140fMiRercty4cYUeTzrCHe+1Y904ESWaDIVLb7/99rMnDk6YzZs3z7v77ruthVAYWEisyzZsyz7YF/v0zqf2wueZyvGnc6JJRridS9FdvCAa0a+FaDGJ65xzzrEnQ06QCDBiisV1xx13xHR7OrDEnJWFOz3dWdKJbqlMsfL2z580aVLS29H/2l1ERP+/4h4+7bTT8nbbbTcraHz38QJhMbvfEhcY8SCE9NRTT1mrmgsELgQQND5v9vv000/HvADMlnA7bwMhBCxrLkoQX7ov4oIv7HfDPPqLLrrIXtjweXHPa7LPZKaDue/k8ccfby189sE5h4toQnwPP/yw9WbE+zwk3AXZjn+yHWcXQgg/QOMguhPSWCRRQpcQ2URZ5UII8d8mLa52PUgd/ETuIYtbCJEzDB482HboomEOJUuUV1GzjnV9ww032BnylJPRNMTblU4IPyHhFkLkDLTWdSMkqcWvVKmSbdTi2nvymK5vmeh6JkRxUbR2RkIIESAYRIJgf/HFF7brF9PVaNazxx572FnbNHhJ1JtbCD8gi1sIIYQIEEpOE0IIIQJETrrKGSPHoAGmYaUzKUgIIYRw4LimVz5TBV1/+OIkJ4Ub0a5Tp062D0MIIUSIWLhwYdwZ5ZkkJ4UbS9t9yKmMKww6CxYsMHXr1jW5dDyZfo2i7i+d7VPdJtn1M71emPDTey6pY8nk62Tjd5LN3wqVCRiDTluKm5wUbuceR7RzSbj5Uvnp/ZbE8WT6NYq6v3S2T3WbZNfP9Hphwk/vuaSOJZOvk43fiR9+KyUVelVymhBCCBEgJNxCCCFEgJBwCyGEEAFCwi2EEEIECAm3EEIIESAk3EIIIUSAkHALIYQQAULCLYQQQgQICbcQQggRICTcQgghRICQcAshhBABQsIthBBCBAgJtxBCCBEgJNxCCCFEgJBwCyGEEAFCwi2EEEIECAm3EEIIESAk3EIIIUSAkHALIYQQAULCLYQQQgQICbcQQggRICTcQgghRICQcAshhBABQsIthBBCBAgJtxBCCBEgJNxCCCFEgJBwCyGEEAFCwi2EEEIECAm3EEIIESAk3EIIIUSAkHALIYQQASKwwj1kyBBTv359s9NOO5kDDzzQTJ48OduHJIQQQhQ7gRTuV155xVx//fWmV69e5vvvvzctW7Y0nTt3NsuWLcv2oQkhhBDFSiCFe9CgQebiiy82559/vmnWrJl58sknTdmyZc1zzz2X7UMTQgghipXACfc///xjvvvuO9OpU6fIslKlStnHX3/9dcxt/v77b7Nu3bp8NyGEECKI7GACxooVK8zWrVtN9erV8y3n8YwZM2JuM2DAANOnT58CyxcsWGAqVKhgcoVNmzaZ33//3eTS8WT6NYq6v3S2T3WbZNfP9Hp+Z8mSJWbbtm1xn8cA2H333X33nkvqWDL5Otn4nWTzt7J+/XpTkgROuNPhtttuszFxBxZ3nTp1TN26dU3FihVNrsAXr169eiaXjifTr1HU/aWzfarbJLt+ptfzOxMnTjRnnXVW3OdHjhxp2rZt67v3XFLHksnXycbvJJu/lZL24gZOuHfddVez/fbbmz///DPfch7XqFEj5jY77rijvQkhhBBBJ3Ax7jJlypj99tvPfPLJJ5FluL943K5du6wemxBCCFHcBE64Abf30KFDzbBhw8yvv/5qLrvsMrNx40abZS6EENlk0aJF5uGHHzZHHXWUDcdhbOANPOWUU8ykSZPiulo5r+GOxTtIj4qbbrrJbNiwocC6X331lbnhhhusAbPLLrvYXhZNmjQxt9xyi1mzZk3c45oyZYo55phjTOXKlU25cuVsWODVV1/N6HsXJUPgXOVwxhlnmOXLl5u7777bLF261LRq1cq8//77BRLWhCgKW7ZssSdCTnQ77LBDkdcTucGjjz5qBg4caBo2bGjFe7fddjOzZ882Y8eOtbcRI0bYc5gDo+PQQw81P/zwg12fOPzUqVPNAw88YD7//HPz4osv5tv/qaeeapN027dvb7p372622247M378eHP//feb0aNH21h+9Lnws88+s70uEPkzzzzTJuW+/vrr9jgWLlxoLwREgMjLQdauXZvHW+c+l5g/f35erh1PUV7jr7/+ypsxY4a9T7S/WOtl8nhS3SbZ9TO9nt8ZMWJE0s8X5T2//vrreePHjy+w/IsvvsgrXbp0XpUqVfI2b94cWX733Xfb89Ett9ySb30es/ymm27Kt/y+++7LW7RoUb5l27Zty7vsssvs+pdffnm+5/7999+8hg0b5u244455U6dOjSxfs2ZNXuPGjfPKlClj328m/5+Luq90t5+fpd9KSWtKIF3lQgjhV04++WRrQUdzyCGHmMMPP9ysXr3a/Pzzz3ZZXl6eeeaZZ0z58uXNXXfdlW99HrOcTpFecInXrFkz3zKsbrc9VrqXTz/91Pz222/m7LPPtt5JR6VKlcztt99ue2MQdhTBQcIthBAlROnSpe29C6ngQl+8eLE5+OCDbdzZC49ZTr8J3Nmp7tuBGx1ww0eD+zyW2At/I+EWQogSAAH++OOPbZOXffbZJyLc0KhRo5jbuOVuvUS4ls/RAp3oNUiaw6pPZv/CP0i4hRCimPn3339Nt27dbPtlEtfoRQFr166NuK1j4RpEufXiQWIb3SGrVatmbr755nzPJfMahe1f+AsJtxAJoL0uJ9vNmzfbG6U+Y8aMsZnAbhnPs54IDojb22+/XSKvRZ+J8847z3zxxRd2OBICnknmzp1runbtar+Do0aNsk2qRLhR7YoQCUCgcXFSiwvEGumJ37RpU5sQBCT3IOAiGEyfPt385z//MXvttVeJiPYFF1xgS8DOPfdcO8nQi7OC41m8rpVmPGt53rx5NuGN8jDKu/g7mmReo0qVKim+M5FNJNxCJIAEoVq1akVa5hILxM1JgwwHFjeWuAgG9913n6ldu3bGLd9Yok1TqOHDh9va7BdeeMEOMkklhp0oPo2ljVAzPOW1114zxx57bMx9eF+Dpi1e6INBk5cDDjggzXcpsoFc5UIkAJFGtGlcwQ0rm+xd95gbz7uYpfA3WKhYv3Qlc16U4hZtmpzQRCXWdwRRpbRrwoQJ1rvjhccsZyASt3iiTbnYCSecEPdYXGnahx9+WOC5Dz74IN86IhhIuIVIAeKI6o4WXHCR4xa+6KKLit09jmifdtpp5qWXXop7YceFIMeC1XvPPffke47HLKfTWSz3OGVkxLRPOumkhMdzxBFHmAYNGtgLFpLYHLjO+/fvby9g6MAmgoPOQEKkAO1NJdzBhDwESqZolVy2bNlie52+ffvahiaUWTVu3Nj069evwDonnnhipBkKiXJvvvmmzTan1em+++5rvv/+e2sht2nTxlx44YX5tkW0ybug1/hPP/1kb9H07t078jffV5q8ULPdoUOHfC1PGVdJa1VCP36ZPy4KR2cgIVJAFndwwb1MWOPyyy8v1teZP3++vcdavvfee2Oug1A64SaPggYoiC1iSl9xar3pH96rVy+zatWqfNs6gf3mm2/sLRZe4XZiz3AS9odrnfI0asm5WPD2TRfBQGcgIVIUbtehSgQHxA9BvfLKK+0wmOKEJDRuqUDm90MPPWRv0UQLN21S04EEtHHjxqW1rfAXinELEQcsa8Ymei3sWK7yWOsJfzF48GAreNdcc022D0WIIiPhFiIOCDHNLLyCHMtVHms94R/Wr19vhZtZ13QWEyLoSLiFSAG5yoPHU089ZePNzMcWIgxIuIVIASWnBS+T/MEHH7TlTjvvvHO2D0eIjCDhFiIFJNzB4vnnnzfLli2zM6yFCAs6AwmRAqrj9g8Me0nUI57GIvfff79tgkKHsmnTppmRI0fGXZ8ueEIEAZ2BhEgBWdz+AdGmB3iiLmmUgNHcBArrMCZEUJCrXIgUUHJaMKDtKEM1GLzRokWLbB+OEBlFwi1ECsjiDgZjx461meS33357tg9FiIwj4RYiBSTc/odGK7QapSlOu3btMrpvxrc+/PDD5qijjjJ169a1cfQaNWqYU045xUyaNCnuvOvrr7/e1pHTcpV2p0wn48IiGhLpBgwYYE499VSzxx572CEk3hGyhcX8jzzySPu+idezPaEEZsiLcKEzkBApJqfJVe5vGM7BkI4ePXpkfN+PPvqo7e9NTTjivdtuu1mXPBY+NyZweXt/M5qTkZlM5WJ9hJRBIgz2oD/5F198kS8pbvr06dZLgGCTUMcwlE2bNhV6oXLppZeap59+2h6XGyLC9DBeg97m0WNBRbCRcAuRQKTXrFlje1tjZXOCjLa4o9cR2YdRlUzVQlQzDf2+x48fX2B+9ZdffmnHZ1522WV28heWNZDVjmhTjnbfffdF1r/11lvtBQC9yW+77bbI8qZNm1qxbd26tRXfJk2amJkzZyY8JrrCIdoMT+Hv6BGifEdFuJCrXIg4cMJbuXJl5MSHaEO0cHvXEdmFCVhYscUV2z755JMLiDYccsghdgLX6tWrzc8//2yXcaHHOE3Ge95111351ucxy3neS/Xq1e3oTUQ7Gf766y/Tp08fO2/7kUceiTn3WxeU4UPCLUSSOHHWidDf1vbee+9tjj/++BJ/bRdCcd8PXOi4qw8++GA7utMLj1nOqNGixKAJC3CxgJXPheUbb7xhLfsnn3zSzJkzp4jvSPgVnYGESFG4FeP2J8SOGVv50ksvmVKlStYmWbBggfn444/tHG3mXDvhBmLVsWD5Bx98YNdLNwb93Xff2XssbcreZs2aFXmOz+C6666z8XQRLmRxC5Ek//77r72Xxe1PyMYmk9qbHFZS34tu3bqZv//+28atnbt67dq1kVnbsahYsWK+9dKBLHQYNGiQfZ3JkyfbaWiECxo3bmz7tD/xxBNp71/4Ewm3EEkiV7l/mTFjhhk9erRNAivJ/x8avZx33nlWKC+++GIr4CUJrw+UpZHVTlIesXNi7q+99pq1uhFvES4k3EIkgLghlhTtNZ11Q6kOj7nxnEtaEyULnz/Z1Mcdd5zNwq5Vq5YV0ZIUzQsuuMCWgJ177rk2ruzFWdrxLGrqu73rpYPbdv/99zc1a9bM91zz5s1t0tpvv/1mKx9EeJDpIEQCqMMlfklc+7PPPrPuTZa52tp//vkn4aALkTnI0v7pp5/MW2+9Zd5++22z5557mldeecW0b9/e3HPPPbZ+2ZVhlYRon3/++Wb48OG2NvuFF14oEFd3sW0X646msBh4Muy11172nnLEWLjlZJ/HW0cEDwm3EAkg+xdL7o8//rBlX5T8eDtZYXHTTUsUD3y+1DU7seYiilKpo48+2lrZNEShU1hJ4hVt4ukvvvhizDIsBBkreMKECfZiz5tZzmOWE5MvSnMUvo/w66+/xoy9k1nO6xZHTbvIHnKVC5EATsjEDznJ0uKSG52u3A0LL9ZJW6QPF0iIIeM4EZzOnTtb0abEi/KnFStWmFdffdXUrl07K6KNexzR5vjIYI/3/09I5aKLLrKtTfEIeOExy4mLFwXXwQ2Bjq4JpywMFzlT0ZSXES70vylEIeDSXLJkiW2hyclYZB66gyHOWNZcJCGQJFrdfPPNVrApsfLDZ9+3b18zbNgwmwBG1na/fv0KrENNdatWrezfHD9jRck2p1xt3333te1YuQDh/V177bUFtvfG6fneRS+j6xod1RyPP/64Oeigg+xFAAlqPMdrffrpp7Y/OuNNRbiQcAtRSFyVbly4NHGR0/dZZCZDf+LEiRGxpv4YD0anTp1skhfjOKmJ9hvM9wasZQaZxILviRNu3NS4+nv37m1ef/11myfB+7rhhhtMr169zM4771xgey4MEi1DxL3CjdX97bffmrvvvtu8//779qKAwSdXXHGFXVatWrWMvHfhHyTcQiSArlbLly+3mcuiaJBFTcMRhPq9994zq1atsi0++WyxChFthmr4GZLQuKWa+U1Pcm7JXix64WIRyzkRxMmff/75lI5LBBcJtxBxwF07bdq0IicQ5TKIjrOqGc5BwhRub4ZxINi4i0u6y5kQQUfCLUSCuCtWIrOW40HSDwlSSv7538UObTgRam6Ub/HZHHbYYbYRCGKd7HxpIURsdLYRIo4AEdumTpZM8nggSrvuuqvJZahp/+STT6xlzW3p0qWmSpUq5phjjjF33HGHzQovSpMRIUR+JNxCxODHH3+0MVhKfkRBEOd33nnHCvVHH31kG3zQEOXss8+2WeBMvpIXQojiQb8sIaKghSmZwM2aNbPZueL/E6aI97tGKJMmTbKxacqQyJhGrPFO+KFkS4iwI+EWIgpqYOkvjfWYy9DOleEZdC8jRk0pFPXLuL4vv/xy6wrP9TCBENlAwi1EVH0xYkXmcybrX8eMGWN7mlPWQ/1yKrANTTvogFXcEB5gpjWWNTXBJOcNHTrUijRWNQJeUv3AC4O675EjRyZ8XogwIuEWwgMZ0TTXOPTQQzO6X0SbYRSUR+FeTgW2Kc7GL3SGcyVbJOQRKthvv/1skxDEmkQzWnf6jZK4kBHCj0i4hfgv1Bh/+eWXpmXLliXeA7skQZi//vprs379ejusg1nWWNE0QBkyZIjtWsZgFYe6xQnhLyTcQvyXKVOm2OzoDh06mLCBSNMK03UtY1DHU089Za3/AQMGmCOPPDLf9CohhH9RyyIh/js+kuEW9JjGNRyWdq0MoMCqJons1FNPtaEAhlFgcTNV6tlnn7VDMYpDtJmc1bNnT7P//vtbi56M80TtQslUP+GEE+yxsj5jMem1zcVULFg+aNAgO7iD/zPmTeMtoYc4yYVe6NrG6ye60fNbiCAgi1vkRMIZ4w05scerLZ48ebIVb+qPsUYTrevnki2S2BiLiRj/8MMP9j3gQbj//vtt17IGDRqUmAv8zjvvtK+BEDNYI9HrvfHGG3a2NSMy6VRHGR4XUoy/ZMoVDV68SXGENZhFjdhzseWmZzHEg9claY3/U9f7nG5tDPWIxccff2xfi2x5IYJAsM5MQqQp3IgZpUyxxJjEMTK9sdw40SMw8db1Gxw7wubqqxcvXmyeeOIJ07RpU3PLLbdYa5uLkGzAfGisZrLimQ192223xbWcL730Umv1IqAkxrkLkauuusrG3RnQwThLb5Y+ok2CGqLvhYsWRmmOHj3adO/ePSLc1JvHgqld4McEPCFiIVe5yHm++eYbK+6HHHKICQLLli2zk6AQLZLounbtaruXnX766VbEsRxHjBhhzjzzzKyJNpDsVthUK+CiiQlsCK4TbUDI3bxrRn16p2bNnTvX3nfp0qXA/vg8gH0WBlY5jWWw2rlwEyIISLhFToO1h3ATh61QoYLxKySXYbWSTIYb+cILL7QCTgz4l19+MXPmzLFWKe7joE3bon0qMIUtGi48iF/jBXFiDc2bN7f31JxH8+6771rR57NIxisAsrZFkPC/L1CIYgRrj4Ei7du3N34sTcMF3qJFC5tcxd8klD333HO2IUomG8RkE9d9bd68eQWeI8ls9erV9u9Zs2ZFEsiwqrHQcZm3bt3aNoZxMW728/TTTxdqQW/cuNGMGjXK7Lzzzuacc84phncmRPEg4RY5Cydu4qQHHHCAL0qhECi6lSHQWJKIFvXURxxxhDnwwAOtYIexGxgJgRUrVjRjx4617WYRYgceBQcJhg4samLTt99+u028IxHP0aNHD1veVhivvfaa9WSce+65WQ0pCJEqwfKpCVGEpiNkjZPM5W50CUMAiKu6ZazDuiXtKiYuvdtuu9n+6FiW1157rS3doqQLixvrOoyiDSQCUtaFl6Fdu3ZWSG+88UYbFiC23aRJE7ueNwTAKFFi/JSXkUFOJQA3LGgufrgYo7d6IiiFA8IOQgQJWdwiZ6zrBQsWmDJlykSWIYokdxEr9g7WQMBLMsaOy5dje/TRR23Xsjp16phcA/GsWbOmtZ7JCOfiqU2bNrYMbODAgba7mzc00L9/f+uZYF3asjooKeMCh8+Uem76rMdi5syZ9sKNUaTOzS5EUJBwi5wAVzhuZ28tMDO3sdy8mc9Y3IsWLSqRYyJLGsHiOIhnkyCXy5AhHitLvFu3btba9sasXVJarAQ0twy3ezxkbYsgI+EWOQGNPRBtr7uZx8Q4o13QrFsSUOqEm/fVV1/NedGOB3XduLxJxqtUqVI+z4gr+YquBnBlYPGmmFH6N3z4cFun7xq3CBEkFOMWOQsnbuKq2YDEKBKv+vbta0477TST6zA+NBqayVCmxf8THdSiE9qgT58+tirAgYvddUiLVw72zjvvmD///NNeDFBaJ0TQkMUtcpbSpUtb66uk+fbbb23mMw1SaM8ZVqiRJo4MP//8c2QZpW1ACZ6rnx48eLDtbc4yYtnkHxC/JpSBWzu6tItscp7HciaJr2PHjnY5MfHp06fbjm2MJU3kJlfttggqEm6R08Jd0hY3iW8M0iBTnPIustrDCqI9bNiwAq5vbg4nnmSQf/7557ZtK2VxJA1iEdO21Vse5qhbt64VbCabkUXOpDM+S1qb3nTTTba9aqxhMVjxxMdJhGP/QgQRCbfIWXDBlqTFjfVIi01i6NQs0/gjzFCqlWgamBcsZmc1JwviSyZ+qttkw8siRCZRjFvkhEBjwUUPDYllccdbNxMZ5LjHSYajjEmxVSFEuki4RehBhGmrGS3GLjnNO7wi3rpFhaYqdPqi2QsDLYQQIl0k3CJnweKG4u6UxqQuhJt4rCxtIURRkXALk+vCXZwxTyaPXXDBBaZ27drm5ptvLrbXEULkDhJukbM4d3hxZZbTxpTWmzRXadmyZagzyIUQJYeyykXOEm1xMyKysD7ltEdlFGhhsE/KnhjD+eCDD9rSKLqkJbt99GuGdcCIECJ1JNwiZ4m2uBHts846K+E2v//+u605TgSdvJhc9emnn1rRZuoXj5PdPp3XFELkDhJuYXLd4s60q5yuXjQS4RarlacQQhQFxbhFzlIcyWl0CmMM5QMPPGC6du2asf0KIYRDwi1ylkwnpxHHvvjii20bz+uuu86EEfqJ9+zZ0ybcMX2LhLtE3dEmTZpkW7xSG8/69BBnuApzyKNhUhf7S3SLHjbiyu0YOlK+fHk7vpU53sl2bBMiiMhVLnICrOo1a9aYypUrRwQ7nsUda93CmDdvno1jE4seMmRIaDPIGYpCzB0h3n333e3f8XjjjTfMGWecYVu8nnLKKbaGnYQ9xJf4PwNBvKM3ycCn13gs8GBs3LjRdO7cOd9yBokMGjTI7vucc86x/6fvvfeeOf/88820adPsdkKEDQm3yAkQ45UrV1qrzIlxPIs71rqJII593HHH2XnRdEcrU6aMCStM98JqJtP9vvvus8M8YoFFfemll9oLGMSajnFAl7qrrrrKXtw89NBD5tZbb80n3NyiYZgI4zv32Wcfc8ABB+SbsoZo77nnntayr1q1ql2OwDPSk8RALhjatWtXDJ+EENlDrnKRs2QiOY2ua2Si//HHH3bOM33Ow0ynTp2saBcGJW/Lly+3QuxEGxDyfv362b+ffPLJfO1m4+HGcF544YX5ljPWEwhLONEG3OV33HFH5DWECBsSbpGzICK4cYuSnMYIyQ8++MC8+uqrpkmTJhk9viCzdOlSe7/HHnsUeI4QBCM3cbPPnTs34X6w3Ilh41Lv1q1b0q/hluGSFyJsSLhFTlOUmdxDhw617t6HH37YNloR/4MYuIv9R7N27Vo7cxvo4Z6I0aNH2/XJH/Ba1YW9hluGJ4RxqkKECQm3yGnSnck9fvx4c/nll9vblVdeWSzHFmTI8q5YsaKdOz516tR8z5FV7iAJMBk3OZn60XTp0sXec+Hk3Q9CzUAXB8IvRJhQcprIGYhH//333wWEm45p3Hiee9ZJNDFszpw5NunpsMMOs6IhCkJiH4ljCC7JYaeeeqrN/Cb2TbIZYYUZM2aYUqVKJfycv/jiC+v27tixY4HnO3ToYN3nL774omnWrJk5/vjjI1nlXIyRLIhoJ3oNIYKIvtEiZyDbmMEfxFbdjRg3AjF//nwbT2UZ67BuPBCKVatWmZ133tn8+uuvJfoeggTJZIgowk0i2eOPP26FlTIwMsGhWrVqcbd/7rnnbPIa09XilddRr/3II4/YtrL8TZ05ddxffvmlvfjiwizaxS5E0JHFLXIGso1r1aqVr3b4yCOPNKNGjbLlXwgxGdNY3IsWLUrY0pQaZjqkMfWLBiNkMSMYoqA727m0vWApYwnvu+++MbdDdOlCx4UVNdnxYB9XX321vXnhQmzDhg12/656QIiwIItb5AyIAKLNpC1322uvvazgfv7551YsWMY6rBsPnqdGmcQqrDysbuqLjz76aGvpicRQ142w8nnhzo4FlvrixYvtOlxspcrLL79s788888wiH68QfkPCLXIeapOJyf75559J1RU7sOR69Ohhpk+fbq12hIa466GHHmo++uijlPYVRmINWOEzIu6NCztW+9LCareTeQ0unkhOw3vCBZYQYUOucpHz0OkMdzfWMx24WrVqldL2WOe09jzttNNsExYEifIwrHAsPgQ8LC1Q6ZxGT3b4+eefI8vIsof27dtHMsAHDx5sY84sI5a9cOFCG+sm6xthjucm5wLq3XffNdWrV7cd6RJB0hu5CS1atLBZ7BzTuHHjbFybjPYKFSpk+BMQIvtIuIUwxlpnNAYhcapu3bpp7YN4K5nNiA0WNx3CpkyZYi8EiIGTiR50EG1iz9Gub24OJ9z0bScEwXhT6rbpKnfMMceYW265xbRu3Trua7B/ssLxZhTWcpbObFxw4RpHwOvUqWNbqtKKFeEXIoxIuIXwNPRAfLH2sBLTBesai5vbY489ZhPfsMiJp2Od1qxZM7AJU4hkspO3KOGKVcZVGDfffLO9JYOrpRcil1CMW+QEWG5YfIksOEQblzlxWDpuJTsZLBG8Ji1RccEj3DQjady4sXnqqacK1JQLIUQySLhFToAIY1EXJsa4ydu2bWuFtrCuXqlAvJv4Lk1b+Puyyy4zDRs2tDXIaskphEgFCbcQUeDeJd5NctO2bdsyum8SqF555RWbiU42O/OkmUHNiMxYGdJCCBGNhFuIKIg/k/SEy5wWncUBLT+JFc+ePducfPLJplevXjZBrnfv3rYrmxBCxEPCLUQMateubVt1Uua0bNmyYnsd+nAzM5rxluedd565//77rYDfeuuttixKCCGikXALEYfDDz/czo0mNp1pl3k0dAdjRCgdxZg2NmTIEOtCv+aaa2yZkxBCOFQOJsR/od3pyJEj8y2jfzmNQxiQQYY41nAq7nP2mQo0KqHr10033WQeffRRm7xGFjqiTv1zgwYNTDqMGTPGTj7zkui9cNzMwBZC+A8JtxD/JZ5Q0ZQFgaMzGuJHY5Hihs5fxL2vv/56M3nyZNO3b1/bbezss8+2zUWaNm2a0v447rPOOivfMiahxXsv0RcwQgj/IFe5EIVA73Gs7eLIMi8MWnYyAnPevHl2vvWnn35q9t57b3P66aebH3/8sUSPRQjhDyTcQhQCtd9kmZMs9tNPP2XlGMqWLWtHV/722282me3bb7+1rVRpsUrNuRAid5BwC5EEtCmlDSpW7tKlS7N2HIwUveSSS+xI0eHDh9tyMhrGMFecvuBhnEjGoJKePXua/fff375/WsomarvKhQwd8Gi4w/qNGjUyd999d9wkP/qo33jjjdazwfq77babbZDzyy+/xH2Nzz77zPZdpzc6eRA00yGMIS+IKAkk3EKk4DJnfvTo0aMTtitlQMaKFSvsfXF6Abp162amTZtmXn31VbN8+XLblY2xopSvhUnA77zzTvP000/bmPzuu++ecN033njDXmDRZrZz5842Q58wBxPbuLiJ/n+jj/yBBx5oHnzwQZsYyPqsR14DHe5ieTNIGqRJz9dff2370ZP537JlS/Paa6/Z2e4ff/xxxj8DIbxIuIVIYXwn1i0NUr744ou46yHYCEJxCrf3mEiaowc6U7j+/fdf880331gByUZMvjhgMAtlclycJJqvjUXN81jkTCtjYhiCjMBeccUVdhnZ+V5IAMRrQRIgCYisP2LECJuch8hfcMEF+T5DPl8uJOiAR9iEhEG63nHBwAUUz/fv379YPw8hJNxCpJjtTXIYYrBkyRLjFxCrY4891h4XjWPKly9vs+SxBEeNGhVoC5zWsJSuFQbCi7iTj7Dffvvl+2wYsQrkB3g/C2r0GS7Tp0+ffPtie8az0pqWEISDCzJa0zZv3ty6yb107drVvhbHIERxIuEWIkWaNWtm46BYtCVhVacCwsGx0fHtyy+/tB3gKAMjJktcGIswrLjcA7rRRUPveZrp4G6nS513G2LhXOhE4/ZDJr+DGd+sT4iC+n4vjIPlouCII47I6PsSIhoJtxApgoWGdUUc22uN+Q1ivePGjTNTpkyxZWXnn3++TdR64oknCjRjCQMIKlA6F83atWttEhqQ2Ofdhv/HDRs2FNjG7ce7PhdGdLXDLd+iRQtz4YUX2va09Jtn5jphC2fdC1FcSLiFSAMSmUhWI266aNEi42fIxibmTUyWhiskYNGBDctz48aNJiwcfPDBNvaMJ4SYvxeyyh3eca1dunSxMexoVznbv/POOwXWB2roSX4jA/25554zAwcOtJ3pGBzTvXv3mNa7EJlEwi1EimzdutUmLhEHxXVKnBQL1t14jnX8xj777GMTr3799Vdz9NFH2/gt7uBYFmoQQTBpUkM4gDj/ueeea8u8uFghto2wOo+Jg450ZKo/8MAD1kPB+uecc461ngmJRK8PJKTx+VH+RV09Fz/fffed3Q9xcdrjClGcSLiFSBFO1AsWLDB//PGHFT6SkchMJn7Kjef8bMnS+xxLkfIxjj1MDVxwXb/33ntWuLmgQkQZ00p5F3XazlviIAeAUALbcQEzePBgm5V/3XXXmdtvv73A+jNmzLCZ64RKuEjAc0FznH333dda3QyLwXUexlCE8A/qVS5EipQrV86eoHGVciOTm2U0aQEsbr+7z4Fjhljx3SCD+5tbNNS9Yz0jsl74v6TkzAsXYM8//3wk1OD46KOPbEIik+OiQcCp/UbA58yZYzPPhSgOJNxCpFE7jWAzQcs1BEH8vJPAWMfvkGhF1y8/ewcyBbkI1ILT7YwmOoVBqIMyOhrdnHLKKZHl//zzj72PV/LllvP9EKK4kKtciCLACRrLlfreoMaFw2RxU2MdzeLFi81FF11kRZgOal6Ih0e3QiVZ7d577zUzZ840V111VcST4hLggE5u0V4VMvi5QKC+27nlhSgOZHELUURoqUk3tSDCRYffLW7c2F999ZX9++eff44so1YdSCpDmIEYNb3NWUZsmlprYt2bNm2ySWXRbnIGx9BQh9al5CtgUZMxTiybODaz0b3QOY+kNJL8GK1Kk5saNWrYhD+y0HHF0xIVb4YQxYWEW4gMdFOjP3gQCYLFjWgPGzYs3zIsW24OJ9xkkFNbT/tX6ra5qMI9fsstt5jWrVsX2DducwaSsC+El0Q2YtO0Mb3pppsKZJTDiy++aA455BA75IV4NhcFvA4d226++WYr7kIUJxJuIYoIJ20sLrpmBc3SCoLFTce3RNPAvDD8g1uy0JgGAY6G5LRYog0sJ7M8Ud90IYoTxbiFSAFO2gg18VKvxU0mOZYX8Fz0On4lCBa3ECI/Em4hUgAxpk2mV5QRaXBx7ljr+JUgWNxCiPxIuIUoIljcEMTMclncQgQPCbcQRYSEJmKlQRRuWdxCBA8JtxA5XBImi1uI4OH/IJwQAXGX0+jDr9DVbeTIkWbJkiW2wQhQ08w0reOPP94O2YhOwqPUiTplIYS/kHALkSGLm+Ygfi0JcwKMeJ911lmRkicGbNC0JJa3gHWFEP5DrnIhMmRx0z4zaG5nxbiFCB4SbiEyQHRJWJBi3LT55KJDCBEMJNxCZIAqVarY+6BllrvRnn63uuk/3rNnTztik8EuhCMSdVNjxjitTKmnZ/1GjRqZu+++u8BAEQftUW+88UY7HIT1if+feuqp5pdffon7Gp999pltp8pQEaasNWzY0PYx//HHHzPynoWIh2LcQhQBZjOvWbPGVK5c2fa9jhZu7/N+bMiCxQ24+DlGv3LnnXfamDxCzChV/o7HG2+8Yc444ww7WpWRnAwBoRc5k8E+/fRT88knn+Qbu8n/Wbt27czs2bPtPYLPPG36nTPxi20OPPDAfK/BIJGrr77afmYnn3yy2W233cysWbPMa6+9ZkaPHm3ee+8906lTp2L9TETu4r8ziRABAmHmxI8AxioJ8z7vR+EOisXNNDCs5nr16tkBILfddlvM9bCo6SGORY5Y77fffnY5SYOM6BwyZIh56KGHzK233hrZplevXla0r7/+evPggw/aZVwYUCXAMJELLrjAJh663uWEFbiQICP/p59+sha3g0x8hLx///4SblFsyFUuRAYT1IIY4wa/J9Uhgoh2YUycONEsX77cTupyog0Ieb9+/ezfTz75pBVyB2M/EeU+ffrk2xfW93HHHWemT59uJ445uBBj7jdTxLyiDYwC5bU4BiGKCwm3EBnCWdxeUfA7QbG4k2Xp0qX2ntna0eDWJhcBa3ru3Ln5tsEF7y5ivLj94C53VK9e3a4/bdo0O+/by7vvvmv//4844oiMvi8hvPjPdydEgC1uXONYY8S7g0BQLO5kQVBh3rx5BZ5bu3atTUID4tEkk7ltmKfOZxAt3m4/rO/Aosblfu6555oWLVrki3Ez0/u0006LWPdCFAeyuIXI4ZKwsFncBx98sI09jx071kydOjXfc2SVO0gYdHTp0sV2k4t2lZOZjhBHrw+nn366+eCDD2yS23PPPWcGDhxo49tNmjQx3bt3j2m9C5EpJNxCFJGtW7faedy0FcUaw/W6efNme2M5z/tduMNicSOYgwYNsglkxKixiinzOuigg2xsG2EFl2gGffv2tZnqtH1t3769Xf+aa64xHTp0MM2aNSuwPjz77LPm6KOPtuVfv/32m73w+e677+x+iIs//vjjJfzORS4h4RaiiHDSXrBggfnjjz+si5zYJ3FUbiz3szXrvANlypQxYeHCCy+05VgIN4lniCgT3CgDo04bqlWrFlm/du3atvUr2+EapwUs1jqCfvvttxdYf8aMGTZznUQ0LhIaNGhgypYta2u/sbpr1apls9a5cBOiOFCMW4gMWK2crHGbYrHhXkUoatasaS3uRYsWGb+C0FDv3LlzZxMmcH9zi6Zbt27WekZkvfD/R8mZg4susth79+5tH9P4xfHRRx/ZXIbDDz+8wP4R8AMOOMB+rtSCk3kuRKaRxS1EEUH4EG1c5a1bt7bJTpQl8ZjlPO9XaBiCALmkrjBDXff8+fOtizuZ5EFCHKNGjbL19zRycdAiFuKVfLnl3iYvQmQSCbcQGQRr7rDDDrNxT9zkfgZvwPjx420WdJggqz8amqlcdNFFVoTpoOaFeHh0K1SS1Yh1z5w50zZuwXviTYCDp59+uoA3hU5rXCBQ3+3c8kJkGrnKhcgwJDRR60sva1pv+r3mOQgzt3Fjf/XVV/Zvupi5ZVx4ACEKhBmIUdPbnGXEpqm1Jta9adMmm1QW7Sb/888/zd57722OOuooW7eNRU24g4sv4tgDBgzIt37btm1tUtqIESNM06ZN7edHW9Vff/3VbsfFGy1R/TjeVYQDCbcQGYYTNlb3K6+8krCndrbBCuU4qUH2O4j2sGHD8i3DsuXmcMJNBjmdzug1Tt02ZXoMA7nllltsKCMa3Ob0J2dfLj+B9qpDhw617U6jM8rhxRdftO1Qhw8fbuPZXBTwOnRsu/nmm624C1FcSLiFKAb22msvWxr05ZdfWsvPb6xYscLeguImZxJYomlgXjp27GhvyVKhQgUrwF5cclo8EHMyy7kJUdIoxi1EESBmiqUVPUAEq5ukL2KgWGN+GzBCg5KguMmFEPmRcAtRBBBkMrJjCTPJSdQIf//9977LLGf0JBccxOKFEMFCwi1EMeG1uhkb6aemKzQj8WZKCyGCg4RbiGKELGVipWSY+2VqGG5yapSJwQshgoeEW4gSyDCn9IpWmX5xk5MRrQYhQgQTCbcQxUz9+vWt5U3NcbatbpqNfPzxx4HJJhdCFMRfqa5ChBRi3Yx/ZIgFQp5pqCV2Qy1wzdNyNRZ0c2PyFZnuNBh5/fXX47rMadkqhPAfEm4hSgDXAvOHH34whx56aMymHkUB0T7rrLMiNcg0IYnFsccea9auXWvry1mPrmFuOyFEMJCrXIgStLrpo+1adpY0a9asMR9++KHc5EIEHAm3ECUE5VdY3rTjJKu7pKEFKDHuk08+ucRfWwiROSTcQpQg9Mqmf/aPP/6YlRGeuNBpCuNnGBDSs2dPOwObzHcy8xO1O500aZLtNU4jHNanz/jdd99dYOKXg8+fyV+ELlifXu2nnnqq+eWXX2KuT1UAxxDrVhz5CkIUhmLcQpQgFStWNA0bNrRWd4sWLQp0XNuyZYt1aVeuXDmjbVKJa3/wwQdm4MCBxu/ceeedNv6OEJM4l2hQyxtvvGEnsNGZjpnZTOliWAijOz/99FPbaMZb9rZy5UrTrl072xCHewR/yZIlNkmPkZxsc+CBB8Z8rV69ehVYxv+TECWNhFuIEoQ5z40bN7YZ3VOnTjVt2rQpINyIS/ny5TMq3Ey9Ylwl4uZ3GNeJ1Ux2/H333Wduu+22mOthUTPkA8sXsd5vv/3sckrumKE9ZMgQ89BDD5lbb701n/gi2tdff7158MEHI8u//vprW9vONLB4OQi9e/fO+HsVIh3kKheihGGMJDO7yexGqEvKTc6oSWLsfqdTp04JJ3M5KHlbvny5HaXpRBsQ8n79+tm/n3zyyXy188zlJqO/T58++faF9X3ccceZ6dOnW2+IEH5Gwi1EFjj44IPNhg0bzLffflvsr7V+/Xrz/vvvhy6bnG50QHObWC7sKlWqWDf73Llz822DCx6PRjRuP7jLYzFixAjTv39/8/DDD9tmOnhPhMgGcpULkQWqVq1qWrZsab766itrLZYuXbrYXgs3+d9//x0IN3kqIMBAU5tYMX2S0GDWrFk2r8Bts2zZMnvRFC3ebj+sH4tzzjkn32NCHi+//LJNohOiJJHFLUSW6NChg43TTp48udjd5AcccEBS7uegeS1I9mNoCvkCXsgqd5Ds5+jSpYu1lKNd5WSmc4ETvT6QwMZzbrY67nS6z5GncOSRR9pudEKUJBJuIUoYarixgHfeeWezzz772FgtAk73M5Znssabhi9kS4fNTQ5YzIMGDbK16cSozz33XFvmRckbse0mTZrY9bxd6vr27Wsz1R944AHTvn17uz6WNBdR5B1Erw/XXXed6dq1q63D5/+sadOm1l1+++23W5FnX0LktHAPGDDAZtpWqFDBVKtWzSaezJw5M986nOCuuOIKs8suu9gfLy5AWjcKEQQ2btxorTTir2R6kzzlHnPP85li+PDhVtjC2tb0wgsvNO+9954VbhLPHn/8cRt2oAyMOm3gPOKghn3KlCl2O1zjgwcPNt98840VdIQ4ev1EUGsOZLQLkdMxbjI6EWXEm4xbfkxHHXWUdU+VK1cucgX87rvvWhcgGbpXXnml7QalH5AIAnyPa9WqZeuLcZNjyTk3NhY3LtlMwAUBQnbSSSfZ1wsruL+5RdOtWzdrPe+77775lvNZUHIWr9wr2Zg1hgMZ7Jm80BIikMJN9qsXOiZxBfzdd99ZdxZJJ88++6zN8OzYsaNd5/nnn7fuK66cKXkRws/QLATRZvoWiVKtWrXKN4mL5zN1Efzrr7/aeuZcg4v4+fPnm2OOOcZe3BcG4YlRo0bZ2nk8eHgpCoOLLi6O1D1NmFx3lUeDULssXEDA+VFR6+kgllW3bl3bRCEWWDHE+rw3IbINlhrZzXT7Kg6wtvlt0LIzrMT6LS9evNhcdNFFVoTpoOaFc0d0K1SS1Yh1E5KjcQseEAfu9FWrVhV4Dbwil19+uf377LPPzuA7EiKAFnf0D+raa6+12aPNmzeP1GGWKVOmQKvB6tWrR+o6Y8XNo7NIgXgisfRcgYzYRO0jw3g8mX6Nou6P7amrxoW7YsWKiLXn9knMm6YiPM/3PNnXxNXu1mF9RIjxoYhLvKxn1vNu55fvDZYvcWhw+S14DVzWN2G0M8880/796KOP2lnkLMN1TfvSjz76yIoz7V1Z5j12nif0Rpc0mtHweX/xxRc2QxwPHp3YWN+9Z1qh0oKVrHzi41jvCxcuNJ999pldhxwcPIHF+fmU1OefydfJxO8kne03pbhdsusXth6/6RIlz8dceumlefXq1ctbuHBhZNnLL7+cV6ZMmQLrtmnTJu/mm2+OuZ/NmzfnrV27NnJjf7x1/s4l5s+fn5drx5Pp1yjq/mbNmpU3Y8aMvL/++itvwoQJeffee2/e1q1bI8+z3D2fymuOGDEi3/p9+vTJK1euXN6aNWsSvhfvdonWK0l69Ohhf5/xbjzv+OSTT/I6deqUV61atbzSpUvn1ahRI++MM87I+/7772Pue926dXndunXLa9CgQd5OO+2UV6FChbx27drlDR06NN//g3vPP/74o12/WbNmeZUrV87bYYcd8nbddde8o446Km/UqFEl8GmU3Oefydcp6r7S3X5+itslu35h66ElJakpvrW4STjjCpurYe80I9yKXCW7QQwOssrjuRyJJ3oHDQjhB/jO4imKLj/KhKfqqaeesuVRycR3/QZ5LYmmgXnBSna5LsmAh41M+2RhEEwq6wuRkzFukj0QbdxftB6MbmfoukxR7uHAnYY7kJIQIfwMIo37lvgroR2E2wvL3fNFuSAgznvZZZdl4IiFEH7DdxY3pWBkjFOTydWxi1tjOdD8gHtqMJnuQ8IanZNIKEG0lVEu/A6CTNtNSh2JcUdPB3PPFwWyqckLoaWqECJ8+E64n3jiCXsfnQlLydd5551n/2ZUH5YLZRtkjHfu3Nlm0AoRFEhAw6UdbXEXlRkzZth9u4xnIUT48J1we0fwxYOaV7JMc7E+VYQD50nKtHBz4bv33nuHbqCIEMLHMW4hcgHi0IR6XMlXpurCSeqip4GSMYUIL76zuIXIFYu7sMYrJGjSl59aawaRJIL6ZAZuXHLJJTZ5k8EXhJMYqBEP9uvt2CaECAYSbiGyEA7C4i6sCgLRZjgIjR+YeFXYPunJTVMRqjKOOOIIM3LkyITDRZLZrxDCf8hVLkQW2vgiyplsdUqf/h9++EFJaULkABJuIUoYN4I2k8JNVUXDhg1tO08hRLiRcAuRhfg2PQky1Sef8q9XX33VNlzJdBe24uSll16yM60Zo0kyHSMyE3VMmzRpkjnhhBNsnTvrN2rUyNx9990FhoY4Vq9ebYeHMJeb9XfbbTdz6qmnml9++aXAuitXrjRPP/20Of74402DBg1M48aN7eswLvSDDz7I6PsWoqgoxi1EBqGximvHG6/7mWvPi1Clum0snnvuOSvYrs9BUGB4B3F2BJIkukRDHN544w1zxhln2JGnlLrx+TG6k+lfdFikk6I3kx4hJodg9uzZ9h7BJ4GPoSHjxo2z2xx44IGR9V977TV74cNkMPIDypcvbwdHsD6jhu+//35z0003FftnIkQyBOfyXIgAgPgiGtzHI1ar02S3jYbJYk8++aSdlkWr1CDxzDPP2C5veAyYyhUPLGqe50IHsX755ZfNgw8+aMf40mmRZTRl8tKrVy8r2nRYJCOf9enIOH78eNu06YILLrANcBxY2G+99Zad/EVv8ltuucW8+OKLZurUqbZb4x133GHbyArhByTcQpQgDMjBhZup+DbWIOIXxKS0Tp062ZK0wkB4EXdGaDKrwIGQ9+vXz/7NxYu3eRMtk/FCRI/zxfo+7rjjzPTp083nn38eWc6gEpZHhxr22msva+kzx7uwkjwhSgoJtxAlCKKdyY5pJKURI47ueR7GLnPRA4eAsEKVKlWsm33u3Ln5tsEFj8s7Grcf3OXJQF08FGXwixCZRMItRAkLN1YdiVJFBaEiXhtEazsV3NCVefPmxSytcxdDs2bNyrcNQ1w2bNhQYBu3H+/68Vi3bp0ZPXq0bVRzyCGHFOl9CJEpJNxClCCrVq2yok2SVVHBPYzFiSs3zDDpjCmAY8eOtTFnL2SVO0jsc5ANTgw72lVOZvo777xTYP14EFsnmfD2228PXA6BCC/y/QiRYUgYIwEqFiSfkUFNA5Zo2IZtk4HtySY///zzTdmyZU2Ywd1NO9eLLrrIxqgp6SJHgJjzd999Z5o0aWKnonnj03379rXxf1q/ksTGyF+yyrGemzVrZn766adCS+duu+02233u6KOPtsIthF+QcAuRYRj2sWDBggIDRHDbItzUCccqfSJxLZagx4L12F+yQh90LrzwQluqRVkWiWe8b+L6lIENHDjQCne1atUi69euXdtMmTLFZpcTTpg8ebJtB4ug169f32bhe9ePhiz0Rx991CatUYqWCQ+JEJlCwi1EhilXrpypVatWgQldH374oV1GrNQlPEVb3IsWLUrqNXCRDxgwwJY70TQEgQk7uL+5RdOtWzdrPdOr3Qv/B5ScRdO7d297T1JfLO666y4r2ocddph5++23bbMcIfyEYtxCZBisMwSahCZ3w0L8+eefrZuWjmne59yNbVKx7K655hpz+OGHmx49eiQVrw0j1HBTDoc7m3rrwuD/YdSoUTZDPNbMckSbEjOas7z77ruhD0OIYCLhFqIEICkKq5B4bKZgf7QIpcMXE8HCDNnd0dAQhbg3IkwHNS/UXUe3QiVZjRaoM2fONFdddZV1vUcnuiHaeESef/55ibbwLXKVC1HM4AIn3oorN9p9XlTq1q1rhgwZYs4991zbQCRIGea4sb/66iv7N94It4zuZtC+fXsrzDB48GDb25xlxKbpcEase9OmTebZZ58t4CYnE3zvvfe2Q1eo2yZ/gJ7jxMK7du1qwwxeuABC/LkIOOCAA8xTTz1lwxFecJ1zEyLbSLiFKGbIfEY4yIh2NceZ5Oyzz7btOum1jbAFBUR72LBhBVzf3BxOuJkbTqczYs58hpRmHXPMMbY1aevWrQvsG7c5/cnZF+Vf5BQ0b97cDB061LY7jc4ox90OtJslMS0eEm7hByTcQhQjCAGzslu0aGFrkYtDuGn9+cQTT5h99tnHlocx5SoIYOUmmgbmheS7VBLwyCOg53iykLDmktaArP9k2rEKkQ0U4xYig+BqxRp07TFxARODxmJMddtUqFq1qhXBjz76KGI9CiHCiSxuITIIoutadDL0AlctCWnJtDj1bpsORx55pE26YoBGpnqhCyH8hyxuIYoJEqFouELLzpLivvvus9nQJKt5x1YKIcKDhFuIYsBZ23TpootXSYFok6xFS89khmgIIYKHhFuIYoDkJrqglaS17aCMiVafs2fPtn26hRDhQjFuIYqp1Ik4c8OGDdPeB93UGHJBdjMDNZKF9emHTr902oH+8MMPNmktug96Yfvl9U866aS0j18IUTxIuIXIMEyh+u2338zJJ59sS7XSxYkm1nsyWekOtz6NREaMGGH7mdMa9ayzzoq5Xjy4aBBC+A+5yoXIMFixuKvp3JVN9txzT/PQQw/ZpiN0EhNChAMJtxAZZNWqVeaXX36xlmxh855LAjqPHXvssdZdvmzZsmwfjhAiA2T/zCJEiCAZjDGQrVq1Mn4AV70bbXnJJZfYbHchRLCRcAuRITZs2GCmTp1q2rZtG3PedrYgSa5ly5Z2KAdTr4IGw0V69uxp52czpIWLkUStUpnERp9ymtmwfqNGjezkr+hpYQ7a0DI1jNAC69Msh77veE7i8dlnn9le6XXq1LEXaiQh0jP+xx9/zMh7FiIREm4hUuw9vmLFCnsfSzCYp421HW+dbFGjRg07XIMZ3nPnzjVB4s4777T910mm23333ROu+8Ybb9hBK0wC69y5sx13ShtZJn/RWY5JbV5okMPsbQaLMHWM9Vnvk08+scl9/J9G8+ijj9q+6XhXmD7GZ8qF0WuvvWbatGljPv7444x/BkJ4kXALkQJ0I+NkHy3KbnTnfvvtZ63tWOtkm4cffthak5SIbd261QQFXP30X1++fLm59NJL466HRc3zWOQ0v3n55ZetICOwV1xxhV1Gsp4XV+9O5j1JhaxPJj4Z9fyfcrHj7UDHnG8uJBgYQ5MbRorSrY4LhldffdU+379//2L9PETw4bvFSNroC8lkkXALkQG+/fZbe9LGTe5XmJj14osv2mll999/vwkKnTp1SmpSF8KLuJ944on2AsqBkPfr18/+/eSTT+aL8xM+IImwT58++fbF9sw3p+8740QdXJCtW7fOjgjFTe6FOd+8FscgRCwYODRz5kx7sYjni3se851KBQm3EBka3Ym7FEvMz9DJjRnWxHzXrl1rwsTSpUvt/R577FHgOcrzqlSpYt3t3lAB2xALL1++fIFt3H4+/fTTfPkCrD9t2jSzcOHCfOu/++679qLgiCOOyOj7EuFg06ZN9jvDJL/GjRubZs2a2Xse//HHH2bjxo1J70vCLUQRwWVKYloqTVKyCXOnsRi///77uAlbQcRNVps3b16B57hIcbPQvT3c2YZ8BP7/onH78a6PRT1kyBD7uTFj/cILLzS33nqrbbZzxhlnmNNOOy1i3QvhhXJMLvwIV5UpU8Z6erjnMctT8dRIuIUoAsQ/cdE2bdq0SCM5SxJOFmRqYwHcdtttJizgTcDjMXbsWJvd7wUPg2PNmjWRv7t06WL/D6Nd5Wz/zjvvFFgfTj/9dJv8Rgb6c889ZwYOHGjGjBljx7d27949pvUuxF9//WUqVaoU8zmWp3IRLeEWIkVI7CKphN7fc+bMsXHPfffd1z7mxnN+T/6iqxsXG4888ohNqgsDCOagQYNsrkG7du3saFPKvPCEENtGWMHbGKdv3742U/2BBx6w2eisf84551jrGVdm9PpAQtrRRx9ty79obYuL87vvvrP7IS7++OOPl/A7F0Fhhx12SGl5PCTcQqQIJ2oGeBAvde4t3K085sZzqcSrsgUxXGqcg5SoVhi4rt977z0r3CSeIaJk+VPeRZ02UPblYOQqFy5sh2t88ODBNl/huuuuM7fffnuB9ZmxTuY6iWhcJDDMhVGqXLhhddeqVcu6zqMHughRunTpuFnkLE+l94OEW4gUKVeunKlbt67NdMZqBU7ePObGc6zjd4jXUgZFKROWY1jA/U2DFDJ4CQeQFY41TUIZ1jMi6wWxpeSMMaz//POP/SxowPLrr7/a52n84mDKGsmIDG2Jhu8Atd+8Lp4YIaITJLnAjwUGQDw3eiwk3EKkCE1WiG8y9pJMZWLGJDfxmBvPsU4Q6NGjh21QgvUYZqjhphYcF3cyJ0hCHaNGjbIuzFNOOSWyHGGHeIlEbjnfASG88DsjES0WeHVSyZGRcAtRRKsV8XYZy0GDdp10C6MVajxrIEjEqoddvHixHbaCCNNBzQvx8OikIJLV7r33Xltfe9VVV5maNWvmS4ADOrlhoXsZN26cvUCgvtu55YXwftfcxV/0jYv/VEYAax63EEUkyMINl19+ue3+RZkTncT8Bm7sr776yv79888/R5aNHz/e/o0bHGEGYtRkzLMMK4a6WWLduMxJKot2kzPulEQ9WpcS8+ckSsY4sWzi2AMGDMi3Pg12SEqjuxphEmam004WtzpZ6LjiaYlalDnsIpzM8pQVRkN5ZipIuIXIgHBjnQUVXHS09nzsscfMzTffbK1wP4FoDxs2LN8yLFtuDifcZJAT03777bftxRTuSYaB0HSmdevWBfaN25yBJOwL4SVBiJMoFzI33XRTzNGsdJ875JBDzPDhw21CGhcFvA4d2/j8/Nw9T2QPlw/jtcCp7aajYapIuIXIgHBT64uL1Q8zuNOBLOonnnjCCmSifuDZgElgiaaBeWH4B7dk4aSJAEdDdUC8/0uW8xn57XMS/iY674XHJEaSDMk5JBWCeZYRIktw0sa68tZd8qNDtF18leei1/E7jKWk+xdDNvxegy5EWCCkwrnD2z8/GSTcQqQAYoxrOVq4wcW5Y60TBHANU8ZETFgIkXlwj1N5QMIkyaCINo2BUs2JkHALkYH6TH54QU5QA2qQO3ToYP7zn/+kbAEIIRJD9QJucZrzcK4gN4LpYOnMC5BwC1FEiFXRI3vVqlUm6GB10znMm/glhCg6VDDQFpdyQUJuNGqi1NBNtUsFCbcQGUxQCzpkYJP9Su9uIUTmwLKOHvtLVUM67XGDFYQTwsfCzRW1X6Gj28iRI/Mtoz0rk81idVPjvVADzTbx1vPum3pmIURyuFAUop1Ol0UJtxAZEm7X29qPxBJWSp5izRBn4AGlTrRxpS453nqO6AsCIURBaIOLULs+CVwcE+v2DrFJFrnKhciQcPOjTCfRxI8nGLqIUd/sZy+CEEHCK9AMIWJYDdPpqlatmvK+JNxCZAD34wtDnBvq169vy9lo3ymEyMy8eGdtE36i+QrL0kHCLUQGcLXcYcgsB1p/XnzxxXaeNZaBX2HQx8MPP2x7jZOly7AGeocz0WvSpEkxt6FRDuNMOXniXeAihWx6QgOxoNaWC5h99tnHnniZ8HTWWWeZuXPnFliX8p7+/fvbsjoyhjkesoi7d+9u+5+L3GXjxo22HIy5724ud7peOgm3EGmCoNFEgXs3zjO6ltu7TtC49tprrciRpOZXEFTatSKiiPcNN9xgB4zQRIa4/CuvvFLg5HnooYeahx56yDa+YNu99trLZtHTKjVWhm/Pnj3N1VdfbROKuGc0KDPM27RpY4Xay1133WXuuOMO+z2gBzr7R/Dpb86Aky+++KLYPxPhT2i6gouc84QrAeOicMmSJSnvS8lpQqQJYrxy5Urr7sKtjLs8lnB71wkSWKRnnHGGtRIQQz8eP01jmBKGGHv58ssvzRFHHGEuu+wyO/zDzce+//77zQ8//GCHjjBIxHHrrbeagQMHWkG/7bbbIss/++wzO4kMC/qjjz6yFjQwIYzSOUaiMk3MgajHGmjCbG+sdI7nl19+KbbPQ/i7a1r16tWtWLsLPjw4zvpOBVncQmSIoI/3jMWNN95oOzy9/vrrxo/QXz1atIHpXYcffrj9/3CjQLGYEWEuorCMvfCY5TzvZejQofaeOd5OtKFLly7msMMOMx9++KFZsGBBZPl5550XcwrZmWeeaRo3bmymT58eirnnInX4/iDelH8h3pDuXAAJtxAZbH0aNuFGhIjpBrENKnF6cJ4CrBzclQcffLB1WXrhMctxuXtDA1jz7rloOnfubO8ZI5rO8YjcOz/88ccfkWFE3HPRl06CmoRbiAyBq3zt2rWhm67F5LDvvvvOilhQ4IT48ccf2xaTxJjBuScbNWoUcxu33K1HPJz4I6VxsZpkRK+fiMmTJ1sXOXFxTuAi91i+fLl1i5NQyWwD4tyEcEhiTBVd+gmRQVc5VininU5tpp/rT1u0aGGtbtzPfgd3ZLdu3exJkri1E13+X1ybyVi4dpRuvVTXjwfP042O/tTE2EVu0rRp04ztSxa3EEUA6xqBIBu5bNmydhlNS3jMjefCYIET6x43bpyN0foZYofEmcneppwNAc8mlPrQtY5SMOLkxMWF8KKsciFKGNypuGVJPFm/fn1EuLGu4J9//klriIAfM8zBz4lViPYFF1xgRowYYc4991zz5JNP5nveWc7xLGQXe3Trpbp+NPy/UxJGZjqZ6rfffnva700En02bNtkKk+jSUM4h7hxBWCYZJNxCFAESl+iARKzKlfm0atXK1nWDi2kFnaefftrGuikL86ton3/++bZNK2VXL7zwQuTiKdmYtDcGzv74vyVGTsMMvCbRce5EMXMsbUSbEjL6vdOUReQ2ixYtsolozjPnFfToqWGFIVe5EEWAkzmijVBjae+yyy42+YjHrilLOtN//AReg9GjR5tLLrmkgBj6TbSpO6fZSbxkMhKBmDWOleOFxyzH4qHTmYNSM/dcNK5+mxrveKJNiIE4uxBbtmyxF4KcI7w3EtXc38niv1+hEAGFUiOs77BBeZQTR7+6xxHt0047zbz00ktxL5Q4QV500UW2tSnxZi88ZjlxcS9crLg6by5gHMT7ybKnW5sLI3jd44g2bVVJ6BMCoi3twpYnQq5yITJ0NU15B9nXYYIsecZ60vubem6/0bdvXzNs2DDrgqTBSb9+/QqsQ+c0wheA25p2qFjBU6dOtW1Iv//+e9tIhVIt2rx6IYsesacxC+t27drVJhPRSpXKgeghLIxDRbTpl16hQgXTu3fvAsdD8hz90UVuUe+/F3icK6h8oK6fmv50vgsSbiEyAKJNHDRsFjeJVViiCJIfmT9/vr3nGO+9996Y63BidMJN3JqGKQgq3eB4f7gv6XHeq1evyPQmL0899ZStBSfO/8gjj9iLBDLFeT3i/rGOh+9Dnz59Yh4PmeUS7txj69atNs7tkhqB2DajPVMNQUm4hcgA/CBx0WJphQlEi/ae0XFcv0ASGrdUIAucnuTckoGTKsNFuBVGkJrUiJJl2bJl9rvUrFkzM3PmTOshIrzGRV6qTVgU4xYiTXBzkVDCPcKNaEfHV73rBA2S7ZiChYuP+LAQIn2wtDlHOOuacwWC7cpIU0HCLUSaIMa77rprRLhjucm96wSN559/3p5ccOUJIYruKo8+D3BBnM4MAAm3EEWEOsxVq1aFSuA4mRDTpbzKOxVLCJEeiDZJae735Xo8aMiIEFnANVgJU2IaHdJoPNKzZ89sH4oQoaBSpUq2xt8J95w5c6zFTXJkqgTPfyeED4WbbGSGjIQFsqPJpG7Xrl2+edNCiPSoXr165G8S07DA080dkXALUURcfDssCVy8H2q3aR06atQom5w2ceLEuOu79q5CiMLj3CSj4TJHuCkHS6ezooRbiCKAywuhO+CAA0xYePbZZ837779vnnvuOeveQ8QPOuigbB+WEIFm48aN9rdE4xVuiDfNfLgwpr9AKki4hSgCq1evtnGrsCSm0dVp6NCh1tqON/VKCJE61GxTDkbHPQdJrSyPNagmEUpOE6II/PHHH/Y+1QYKfoUe3Lwnv3ZKEyKoYGFH58Hw2GWap4KEW4gigJucK+h0BgX4tVMaPbn333//bB+KEKGifPnytjWvF+Ld6ZSDyVUuRBGI13gliBB/e++996x4CyEyC0loVGgQz6Y3AtPmiHszBphYtyOZ8jBZ3EIUcSJYWISbCVhc/RPfFkJkPpGVvBGyyRlHyz2PWU62ubslgyxuIYrQyzssE8GIsyHc5557blquOyFEYjKZwCqLW4g0CdNEsLffftt6D9QpTQj/I+EWIk3cRLAgDhCJ5sknnzRt27Y1LVu2zPahCCEKQcItRJpQNhUGN/lvv/1mPvroI1nbQgQECbcQaUDTFZonhEG4mQJGZuvpp5+e7UMRQiRB8H18QmSBsEwEY7Qgc7e7d+8emlp0IfwI5V/JkMwYXQm3EEWYCOZtXxhExowZY5YvXy43uRDFzKxZs5Jar3nz5oWuI+EWIocngtFs5ZBDDjHNmjXL9qEIEWpq1qxpO6VVq1YtMmRk2bJlpkKFCinPBVCMW4gUoWECiWlB709O+8Xx48erL7kQJQCeLWq58dRRicI9j1lOWam7JYOEW4gUWbNmTSgmgtHidJdddjGnnHJKtg9FiNCzbds2eytsWTLIVS5EmhPBgpyYxoXHwoULzfnnn2923HHHbB+OEKGn0n9n2++2224RVznWdjrjcyXcQqQR32YcX5CzsEePHm2zXC+55JJsH4oQOcHuu+9uhZpWyYg24k0ZJkKeKhJuIXJwIhhJaVdeeaVp1KhRtg9FiJxgu+22s4lp3IqKYtxCpABDRRjBF2ThnjZtmpkwYYKpV69etg9FiNDnwyQ6l6xcudLMmTPHpIosbiFSYPXq1fYHF+TENKzt6tWrh2I4ihB+ZvHixbbcy5stTjUH5xFKw8gsJ0E0VSTcQqQAMapSpUoFVvQ2btxohg8fbq644gr7PoQQxQcjcufPn28bNRHXRrCBHBkunpPpkhYLCbcQKbBixYpATwR75ZVX7JX+xRdfnO1DESL01KlTx7rLmWtAJcdOO+1k+z8UNbE1mGcfIbJoce+1114myOM7O3fubPbYYw9bmiKEKN6ENKxrbps3b7YWN787LvzJKOdGdnmqSLiFSBKumNetWxfYxLTvv//eTJkyxYwdOzbbhyJEzrHTTjvZkjA8dni9EHFanpYrV87Ur18/pX1JuIVIIdEEgpqYRlIaFx1du3bN9qEIkdNWeMWKFe1ty5Ytkbh3Kig7RYgUOqaRTBLEiWBc4Y8YMcJcdNFFgY3PCxE2dthhh7QasEi4hUjB4t51110DORHs5ZdfNps2bbLCLYQINhJuIVKYCJbO1bEfjp2ktGOPPTawbn4hxP+QcAuRBJR0YLFicQeNyZMnmx9//NH07Nkz24cihMgAEm4hkuxPDkG0uElKq1u3ri0DE0JkBxqxrF271nrAioqyVIRIUripuaSkI2ieglGjRpk77rgjX9tFIUTJQr024TY6FnIuobY73fOJhFuIJIU7iPHhF1980bZavOCCC7J9KELkNLVq1bKhtt9++822HmbACL3KEXBmcqdyYS3hFiLJiWDNmjUzQUxKO+GEE2zjByFEdkGcsbj33HNP20kNjxhNWJYuXWrrupM1DhTjFqIQGHxPo4SgdUxjdOf06dOVlCaED8FNzmxuho1QYppoBGg0sriFSMJN7iaCue5pQQBru2HDhuaII47I9qEIITww2hOhpoUy5xbXzzxZJNxCJCHcXBWnMwwgm1PMRo8ebfr27avxnUL4ALx2xLW5J8OcOd24xrlPtamThFuIJIQ71SEA2WbYsGFm27Zt5vzzz8/2oQghjDEzZ860F/8YAelOBXNIuIVIAAkkWK8HH3ywCVrt9imnnBLIunMhwki9evVM+fLlM7Iv+dCECNlEMC40Zs+ebS699NJsH4oQ4r9QmcJvE1d5UZHFLUQCaJiw4447ml122cUEhd9//900adLEdOjQIduHIoT4L9RqI9xUqRDXJhkNCzydoUUSbiEKiW9TBhaUiWCcFLiypwQsKMcsRC5QrVo1K9Z4w2DBggW2rttllDMyOFkk3EIkaGCCcO+7774mKDz//PO2kUP37t2zfShCiCi4mKbKg9kBNHaiJGz16tVm+fLlply5cmaPPfYwyaAYtxBxYCAArQmD0niFLPKnn37a1KxZ01StWjXbhyOESADWNi5zLrT5m+mDySKLW4hCJoIFJTHto48+MvPmzbPZq0II/3ryVq1aFRkV7DqoUSKWLBJuIRIkpvFjwoUVlE5p++yzj6xtIXxcWoqLnFwUktWYIcCgkVSRcAtRSGJaUI717bffNo888ki2D0UIEYM5c+ZYIwAPHu7xonQ0lHALkWAiWNOmTU0QePbZZ23Z2rnnnpvSsAIhRMnQuHHjlDLHEyHhFiIGjNoLykQwjnPo0KHmrLPOsu43CbcQ/oNEV26JSHbQiIRbiAQTwYIwx3rcuHE2Hq9OaUL4+5xCIloiJNxC5MhEMPqSU2u+//77Z/tQhBAJaNCgQUam9amOW4gYYMFSDx2E9qbvvfeerG0hcggJtxBxyjaCUL/9zDPP2H7HxLeFELmBhFuIOBPB/J6Y9u+//9pscjLJMzUuUAjhfyTcQsSIb1Nateuuuxo/Q922GygihPA39CGnVzmd04o62lPJaULEEG7i236frkVSWtu2bU3Lli2zfShCiEIoW7as7ZhGu1PmCpCkRpdDkmBTPdfI4hbCA1fDJKb53U3+22+/mQ8//FDWthABgQlgf//9t2nYsKEVbTLM//rrL9szIlUk3EJ4WLdunW2S4PfENBqu0Ef99NNPz/ahCCGSgMZIePIIw2FhU9Ndp04dO4UwVSTcQnjA2gY/W9z//POPee655+zMbdxvQgj/Q1w7ui8E4zxpr5wqEm4houLbtA31c5b2mDFjrNtNbnIhggMi7ZLSCMkR5ybmnc7Ft4RbiIBNBGN85yGHHGKaNWuW7UMRQiQJxoC3V/n06dPtPO50Gj0pq1yI/8IVMOVVhx12mPErM2bMMOPHjzcvv/xytg9FCJECXoOgfv361m2ebktlCbcQ/4XsTpqa+Dkx7emnnza77LKLOeWUU7J9KEKINClqboqEWwhPYhrZnn6dCEbpyLBhw8wFF1xgM1OFEMFh2rRpSa3XvHnzQteRcAsRkIlgo0ePts0bLrnkkmwfihAiRfbcc898j0lUI8mUZNhULXAJtxAe4a5bt67xc6e0I444wjRq1CjbhyKESJFYs7hZNm/ePNtBLRWUVS6EMbajEVe/fs0ox802YcIElYAJESIIzZFXkyqyuIUIwEQwrG3c+CeccEK2D0UIkQaMCo6uYqFTY7ly5VLel4RbiP+6ycuUKePLiWB0Vho+fLi54oor7DEKIYLH+vXr8z2mX3nFihVtlUiqSLiF8DRe4cfkx2PjR3/xxRdn+1CEEEUY65kpJNwi53ETwVq1amX8yPz5803nzp0z+sMXQpT8jIF4pOpJk3CLnIc404YNG3wZ3/7+++/tVKFLL70024cihCgCs2bNKlLtthcJt8h5cEWDH4WbpLQ2bdqYrl27ZvtQhBBFoGnTpvkek01Ot8YKFSqkvC//BfSEyIJwkySSzg+oOCGuPWLECFtbvsMOusYWIujTwbb33KjhxligDDVVJNwi50G4/difnEEiTA/yc1MYIUTR6rgpCyPPJhV0GS9yGn401HAfeuihxk/wQ2Z857HHHmt23nnnbB+OEKKIeEd6eqlTp44V8FSQcIucBjeVHyeCTZ482fz444+mf//+2T4UIUQGWLBgQYH+DEAJarNmzcLjKr/vvvvslci1114bWbZ582bbiIKidQaTM97wzz//zOpxiuDi14lgJKXVq1fPloEJIcKRnNbUc0OsafhER8RU8a1wT5kyxZ68WrRokW/5ddddZ95++23z2muvmc8//9y6OU8++eSsHacIfny7WrVqvupIRvnXqFGjbMMVkliEEOGjVKlSVrRDk5xGTe0555xjhg4daqpUqRJZvnbtWvPss8+aQYMGmY4dO5r99tvPPP/882bixInmm2++yeoxi2B3TPMTL774onXfM3dbCBHuuHdeiolpvo1x4wqnbrVTp06mX79+keXfffedPaGx3NGkSRObdfv111+btm3bxp38xM3bcEMIvhPUUR544IHGb0lpDBPxm/teCJE+M2fOLJAYS5y7Ro0aJSfcf/31l02gIUbI1BMGge+2225mn332MQ0bNkx3t9ZFSLcoXOXRLF261Lo0K1eunG857gaei8eAAQNMnz59YiYL+K12tzihtOj33383uXQ8iV5jyZIlEZdVsseRzjHzOvxIgQxx1/AlXlvEe+65x3qa8CRxbJUqVUrpNZM9xkyvFyb89J5L6lgy+TpF3Ve6229KcbtM/QaiB4jEIvpCfMuWLXa7tDQoLwU2bdqU99xzz+V16NAhr0yZMnmlSpWyt+222y7yN7datWrlXXnllXk//fRTKrvPW7BgQV61atXyfvzxx8iyQw89NO+aa66xf7/88sv2daNp06ZN3s033xx3v5s3b85bu3Zt5LZw4UJ8E/bvXGL+/Pl5uXY8iV7jyy+/zOvfv3/e1q1bM7K/eIwYMSLp7c8555y8hg0bRo6JbVN9zWTXz/R6YcJP77mkjiWTr1PUfaW7/fws/VbQknQ05Z9//smbM2dOXqokZXFjBTz88MM2y5vEGaxr3NL777+/tXarVq1qLfBVq1ZZd8CkSZPMkCFDzOOPP25j0Q888IBp2bJloa+DKxzX5b777htZhivhiy++MI899pj54IMP7LFwDF6rm6zyRO6GHXfc0d6E8ILlW7NmTd9MBMNzNXr0aGtx++WYhBDFB79zbxg3WZIS7saNG9uTHHG3c88918afS5cunXCbuXPn2iSbYcOG2SQyEs3OP//8hNscccQR5ueff863jG2IY99yyy22UJ3X/eSTT2wZGHChgMu7Xbt2ybwVISLwnY6uWsgm/FaIcZ933nnZPhQhRIbBKPVC+AxXOWXNqZLUZf0hhxxipk+fbq2BE088sVDRhgYNGphevXqZ2bNn27KuZMDXz5QU761cuXK2Zpu/ifVdeOGF5vrrrzefffaZtdARdkQ7XmKaELEgQZEfjV8yyhFsfieUNpIrEnReeukl07NnT+uVw9tFrfwLL7wQd328dBgG1LWyfqNGjczdd99tPXmxYDnVJXjnyAfAA4dX795777XVJ/EYP368fR1KAHkdjIGTTjrJNrsRojihB4n3Royb7246zZ+SsrixnNOFOlTENlM89NBD1r2AxY2LgQYVuOSFiAU/DlzQnNi9gzpcgpj70bCeC8FkY6AHF6Jc5OKZCgN33nmnTeZBiEnKSZTY88Ybb5gzzjjDniv4XRP2mjBhgg0ZfPrpp9bD5g11UVly+OGHW7FnhrrzUPAZ8rojR460ibOE9Lwg6jxPeAQDhGMjzMZr4elLJpwnRLpkcuaAL8vBoq+QvTBRhfg5NyEKA3fUypUrrTvKK8hUQ+DhcRmdCHes9UoKrG1CQh06dDBh4JlnnrFWM93fyI257bbb4lrOzBrHIkdACas5D8RVV11lf+dcrN96662RbcaMGWNFG0sZ0feCIL/55pvWO9i9e/fIcpYh2jzPxLXo/u/8/wtR3Oei1atX2wtUvMep9if3ogwYkZPQcc8v/cmx+hAgXMtF+TH7CXotINqFQckbnaMQVCfawOfgejhQ1+5tUkH+DHTp0qXA/tzc8uhuVAg/F2m462MNbdHYVFHcYCyQwM3v3cW7EfKFCxemvK+0v63z5s0zjzzyiI0NcRLEfRUNP77ffvst3ZcQolgngvnFuqX7H1fhXgsxV3D9F/bYY48CzxG2IAaImx2xdv0hyHeBcePG2bawXt5991173sGV7uAcNWPGDJs/gEeF7X766SfrSuc7IBe5KKmOoHvttZf17vCdpiKrYsWKac3aSEu433//fXuFTGkWiWokesS6Yk2nlZsQxQ3WGN9dPySmcRHx9NNP2xgvZZW5BnFmZwhEQ5IZFgnMmjUrItxY1Zx/cJm3bt3aHHbYYZEYN/vh8/SWlJLECny+Bx98sHWze6G98nPPPeerfvUifJQqVcpeVJKv4UIzLHPNmYpduCnNwkJ45ZVXbDKJak5FkCAxjR8QSUrZ5qOPPrJiQxZ2LoKQYnWMHTvWTJ061Qqxg6xyB4mDDv7vXn/9dXP77beb+++/3/zwww+R53r06GGOPPLIfK/h3JJ4NrDsSXhr06aNTQakvfLLL79sL+IGDhxYzO9W5DK77rqrTZTF0HWQV5NOj5G0FJer37PPPtucdtppEm3he2jiQwWCK8Og7p8fEVe6bhnPu/m4JQnWIW2Cc7UPAa5ryroItfEZ0CfixhtvNAcddJCNbZOwB97zDO0nSUwjXk0GOSdDbrRLxht4wAEHmPnz50fWdxYN9xgbuNF5XS4SuGDgbxo8pdMIQ4hkQaTx9v3666/2u8g9j9MZ65mWxU25BtndQgRlAg9i7Vyh/FgI8XhLlHCdI+AlDRfBuHrDkpSWDpSL4v3Aeib7mwsoLGLKwLCCiU97rZT+/fubt956y657/PHHR5YTbuC8hBud0i9XWkcGL5CM6HWhA/ulB8THH39sT6SUlwlRHET3Kie8zPc1HeM3LeHG2ubKlROdBFz4HZr44Ap1LiksLCw8b9Yz1lai4R/FBb8fLhpyHTLEY2WJd+vWzZ7YvIJLchl4E9AcbhludwcJQRA9nMjhlsdr9iJEJiAklCnS8nP37t3burBofkLtJdlyQvgV8jEQbUSSm+v85x5z43nWK2koTcqGpR8EOLfg8j766KMjVjO4C53oki/vMm/cEIuaz5nM9FifNV0hoX79+sXyPoQAEi3j3UpEuDnxXX311bbbEOUU/Kg46UXfVBsp/Ei6mZzFARcNuW7p0X42Gsr1LrroInsOoYNadEIbMKrX+/+Ii502y9HWOB4WLHdCJq423NsVEuFu37695p+LYo9xe2+UgfE95+9USUtZcZNTQsGPhp7kfOEl0iIo+E24w2hx0zntq6++sn+7wUEsc50QEUqEGQYPHmyz6llGzJmGFMSvSUJ79tlnC8SlySbn+eHDh9tSLyYQAjFxRJiObTfccEO+bYiL89rEvjkueqiTVf7222/bWvFk5ykIkS577rlngWUkVZZYOVjfvn2tlU0GJ0kkQgQJPwk3Ltx0XGV+B3Fk2lm065ubwwk3GeSff/65FVE+C4YKHXPMMbbs1Fse5u35jGAPGDDAnoMQXZL7cHXfdNNNtr0qYuyFfX799dfWSqf+m45t1HWTxU7oDwNEiJKG72V08mWxCTd1p0zlkmiLIEIYJxulX7nkKqdUK9E0MC9YzM5qThay0B999NGUtkGo6fbITQg/gFcpnYqStISbUXh+OfEJUZh1jfXlDeXEsrh5nqvfkg75KDlNiNxgzpw5+R5zDqK6JZ067rSS0+gPjFuLhulC+BmEmGYryQh39HolQVgtbiFEfjAMvDf6oZCP4dr+pkJaZ6lTTz3VxqrI7mRUHk3649WoZXIGqRBhi3GHNTlNCJGf6LyLopCWcJPIgV+eISKJJhqxjubcCr/hpxi3XOVC5AbL/tszPxYlkpyGWOdyi0YRbPxmcctVLkT42Rx1gU58m2X0GUiVtIQ72WxRIfxISQs34swwDKDNKqVIDjxSlD6552NtK4QIPnVjhI0ZXUtjoFRR1xSRk8Jdkq5yJlk5GGxC3bJ3OhjjK2kmEs+L5R2GIoQID+SGMSMh1RHDaWWV052IbkexegU7Xz7PM21HCD/GuP3kKndlIUKI3GLNmjVpzUhIy+K+7777bHvBK6+8MubzpLr/5z//sRN6GF4vhJ/wU4yb5DQg1uXGjgohwsevv/5qE7od/I2XjcmFJSLcX375pTniiCPizhHlCoLnv/jii3R2L0TOCLeLYZOglsmxf0IIf8e4OQ8xxa7E5nEvXbrUdk9LBFcRS5YsSWf3QpSIcLsrXj8It0rChAg35cqVy9i+SqV7AIlq0oDnlREr/IiLKXndVn5wlQshRLEJN2P2xo4dawPrsWDCDxN4osfxCeEHnGvKD01YvK5yIYQoNuG+4oor7PBvhtVHx7EZz8dyxDte8poQfhBuP8S55SoXQpRIjPuEE04w1113nXnooYesSBNgp2E6se+///7buiCZi3viiSems3shSsRV7gfhlqtciNxmy5YtKQ83SsvihgcffNC89dZbpnPnzjbm/ccff9jWbV26dDHvvvuuGThwYLq7FqJYkatcCJFNoaZj2uLFi83s2bPNzJkzS7Zz2rHHHmtvQgQJucqFECUNVVa0N8Urze8egxdPdTrZ5mp5KnIOPwm3c5XL4hYi3KxatcqWnzJ/m54NiHe65ahJucoXLFhgigr9WIXwA36KccviFiI3aNq0aaQJC27yGTNmWG0l0btYhLtRo0Y2k3zevHkp7Zz+y0w92nvvvc2zzz6b8sEJEfYYN8dCq1MJtxDhplSpUjYPrHr16qZ+/frWTc7vPp1GZUm5ykk069evn3nyySdN+/btzamnnmratm1rWrVqZUqXLp1vXZLUJk2aZD766CMzevRoWxZGAtvZZ5+d8sEJEXZXOWgmtxDhZ/369TbGvWHDBpugRmwbt3mxxbivvfZac95555lBgwZZy/maa66xvnlOgJUrV7Y3rhzw4TvLgecR7BtuuMF07Ngx9XcpRA4JtyxuIcLN77//bs89DOHilmoJmJekt0Sc+/bta3r16mXGjRtnp4NNnDjRWtgLFy60STb0J99nn33MoYceamu969Wrl/aBCZELMW7gtyPhFiLc1KtXL2Jxr1ixwvY/wdrmluqAoR3SOempDEwEGT/FuEGuciHCT4UKFezNnXsQcW5//vln8Qu3EEFHrnIhRDbBAEas0x3lK+EWOYcfXeWyuIUIN6tXr477XJUqVew9g7sISxeGhFvkHH50lcviFiLcrExQr+2EmwRvCbcQMZCrXAhR0uy5556FrtOgQYPiHTIiRFDxm3DLVS5E7rIgjc6ksrhFzuG3GDcWN7EtIUR4WbdunVm+fLltvhLdYdRNCNtrr72S2peEW+Qcfotxq45biPCzZMkS23iFFsde6IOy++67p7QvCbfIOfzmKlcdtxDhZ9u2bbbFaTR0GS3ROu7JkyebKVOmWDdfLOuFA7rrrruK8hJC5IRwy+IWItxUqlQp5vJkssgzItykrJ944olmwoQJJi8vL+56Em7hR/hecvOLcCs5TYjwU7NmzZSWZ1y4r7/+evPVV1+Zww47zPTo0cPUrl27SA3ThchGgppfYtyyuIUIP9OmTUtqvebNmxe6Tlpq+84775gDDjjADhrBchEiiO5yv1jcEm4hcq+Oe8uWLTbLHBd62bJlU9pXWsKNW69Dhw4SbRFY/CTccpULEX522mmnmMvmzZtnqlatmtK+0mrA0qpVKzN//vx0NhXCN8LtJ1f5P//845sLCSFEyYDxSx13qqRlcTOT+/jjjzfffPONadu2bTq7ECLrMW4/Wdzw999/R/4WQoSLFStW5HvM+YemLMzjLhbhHj58eIFlXbt2NYceeqg555xzzL777hu3Dq179+4pH5QQueQqdy403OUSbiHCyfr16wucg9BNmrIUi3Cfd955BeLZrgzshRdesLdYz7NMwi38iB+FWwlqQoSXPfbYI2P7Skq4n3/++Yy9oBB+wE8xbmdlK0FNCJEx4aZWW4gw4acYtyxuIUSxZ5UT8/7pp58KLTaPFRsXwg/IVS6ECCppCTcx77FjxyZc58033zTnn39+usclRM4It1zlQohiF+5kIH7ohjkI4Tf8JNyyuIUIP6tXr46bV7Np0yZbDposxaasU6dOTbkbjBAlhWLcQoiSZNGiRbZxWSzx5rf/559/Zr4BS8eOHfM9pgRs/PjxBdbjoP744w97gKeffnrSByJESaKsciFESZ9zdtxxR6uN9evXt8aDg3ruZcuWZV64vSJNfTYvHqvtKQeHpX3aaaeZhx9+OOkDEaIkkatcCFHS1KpVyyxevLiAeHOfaER22q5yTnLuxgv07t073zJ3Y+IJVw6jRo0y1atXT+/dCZFDrvIyZcrYi2FZ3EKEm+22286KN162uXPnRi7WiX9jjRdrr/LPPvvMXi0IEWSLm4tMv/yYNdpTiNyhZs2a1sD97bff7LkIYzgVTU1LuOlR7oUrh7Vr19q5og0aNEhnl0LkrKscJNxChF+svVSrVs2Glfnd8/vfYYcdij+rHKG+5pprTJUqVUyjRo3M/vvvb+95fO2119rnhfArfhNuzeQWItxUrly5wDLEunz58imJtt0unQPAxD/kkEPM7Nmz7cFggRPPJp39hx9+MIMHDzbjxo0zX375pb2qEMJv+CnGDbK4hchd8v6bmBY9rCujFvdtt91mRfvWW281CxcuNJ9++qkZOXKkvefxLbfcYp+//fbb09m9EMUOPxC/lIOBhFuIcDNz5sy4xsKqVausdharxf3222/buu7+/fsXeI6h4AMGDDCTJk0yb731Vjq7FyLnLG65yoUIN//++2/CC/cVK1YUr3Bv3LjRtG3bNuE67dq1M5MnT05n90LkXIxbFrcQ4Wf27NlpCXtGhLt58+Yxm6944XnWE8KP+E24ZXELEX5q1KiRdBw748JN7PqMM86wU8I6depU4PkPP/zQjB492t6E8KurXDFuIURJUqFChYwM30pLuCn1Ouqoo0znzp3NkUceadq3bx/JKieT/OOPPzbHHnus7QYTPZO7e/fuRT5oIcJmcSPc69aty/ZhCCGKCTqmZcLaTlu4sbQ5AFLYsa65xUpge+eddyKPWZdtJNzCD/jRVZ7KdCAhRLCgx0mmSEu4n3/++YwdgBC5Ph0M5CoXIvxs3brVetb4rWM4cB7it890MO+0sGIR7h49eqSzmRA5XQ42ZswYG1KaOHFiged2220307p1a9sPIZp69erZbfiBn3TSSSV0tEKITLJp0ybz+++/m9KlS9vfsjMeKANbunSpqVu3ri2nLjbhFiLoZMNVzlU2ca6DDjqowHM0LaKB0VNPPVXgOX7sbBNL1IUQwYBxnmSVx3KZkw+2ZMkSs+eeeya1r1JFtSBOP/1006JFi3wvOGPGDHP//febRYsWFWX3QuRMjFuuciHCzd9//x2zXzmwnOeTJS2LmxPeWWedFSn3iq5B5YrijjvusG4A2qMK4Tf8GONWHbcQ4WXHHXe0ljUTwaJJdR53Whb3Qw89ZF577TXTs2dP+4I33nhjvueJ4zGE5N13301n90LkZMvTMFrcL730kj1PMD2QExOVJS+88ELc9WmVfMIJJ5hdd93Vrs/EwbvvvjvuRQ3LBw0aZPbdd19rMGC5tGzZ0tx7770FJhSOHz/evn6iW8OGDTP+GQjhxnpSOUL3NPqS4zrnnscsjx77mXGLmx9emzZtzOOPP24fx6pNw3Uu4RZ+xTVBcJmd2SasrvI777zTxugR4t13393+HY833njDNnbiouqUU06x8cAJEyaYe+65x8b/P/nkk3xWCS0iDz/8cCv2rVq1smWq8Nlnn9nXJSeAtstly5a1y+vXr2969eoV87XpPcFr0ZtCiOKA72Hjxo3zZZUzzpPfRolklc+ZM8dcccUVCdfZZZddzMqVK9PZvRAZZcuWLWbNmjXWGnNzb2MJd6z1StLixnWPGJF1GhaeeeYZazWTGX/ffffFDZ1hOV966aXWCEBA99tvv0j/h6uuusoMGTLEevqYSOjNsUG0ybRH9L2ceOKJ5s0337ThPNc7AuHu3bt3zNd//fXX7f1FF12UsfcuRDSIcybquUule5KJdkNFw5V1vEC8ECUJgsxFJPcOr3AnWq8kLW4Im9VNS2REuzAod1u+fLkVXCfagJD369fP/v3kk09G5hbD3Llz7X2XLl0K7K9r1672nn0WBlb5tGnTrNWOy12I4oDhXIXdkiUts4J60w8++MCeZNwJJ3q26Pvvv286dOiQzu6FKHacW8ovcW6vcNPPONegjhX22GOPAs9hAGClYAwg1i4O7YYYjRs3zlx88cX5tiFMh+jjSk/GKwCytkVxsmDBgnyP8bB53eM8TnYwV1rCffXVV1v3FHGo6LrT3377zVxwwQXWImc9IfyIs7j9klmOFwtyNbOcOB/MmzevwHOcS0iChVmzZkWEG6saCx2XOcbEYYcdFolxs5+nn366UAsaK2fUqFH28z/nnHOK4Z0J8f80bdrUePn111/zLZs+fbpJlrSEm6xPGkYMHDjQusFct5dq1apZVyPurLvuust07Ngxnd0LUezEcpVnk7C6ypPl4IMPtgk6Y8eONVOnTrVC7CCr3EEOggOLmtg00wrpG/HDDz/k6+7IAKTCoDpm/fr15txzz1VoTwSGtNNpBwwYYN3lTAEjW86V1xx99NHWddWnT5/MHqkQOeAqz1WLu3z58rasi+S8du3aWSGlzJSOccS2mzRpYtfzVgDQQhLPH1UuZJDTOpIbFjShugMOOMDMnz8/4es+++yz9v7CCy8s5ncoRH5IgHW/dy7Yiz2r3MEVbTJXtUJkG1zi3s5ECATww3ElRjyfLde5K1lKJUElbCCe1LJiPZMRzv8FZaeUgeHdoyMjXj1H//79zVtvvWXXPf744yPLKSnjQgg3OvXcQ4cOjfl6M2fONF999ZUtXXVudiFKikqVKtkLSzzWXISmkm2uXuUiJ0AQSQ4pU6aMfUzzA5cU5Sok/vnnn6y5qqlZdseTy5AhHitLvFu3btba9sas8exBrAQ0twy3ezxkbYtswkUopZ+cc/g7Vke1jAo3PciJRU2ZMsW6ptx0I66OcV3RaEEIP8FVLQM+nHXtLFuymL0Wd7b669P3gIsKd0Eh/gd13VgmxxxzjLVSHFxouZKv6Ex8VwYWr40kJX/Dhw+37krXuEWIkibdmu6UhZvOQ7iy+NF4ayqBHwJxKZoskJwmhF8gfsRJ3MWSXbc/TvjeuGkqcaZMwvHgJs5l4aajFAlqXvg8KNNCYOmgFp3QRv01+TTPP/98vkoB1yEtXjnYO++8Y9tM4mJ33g4hihNCM8mw1157ZVa4GRxCUhonQJJHiAu5/qr8wCjDIEuT7kT8eOJ1KRIi23DhiUj7od2pg99S2CbqUSNNHBl+/vnnyDL6hkP79u0j9dODBw+2vc1ZhuuQPs7Er4n/4daOLu0im5znMRi+++67SBULMXFKa+jYdsMNNyR0k6t2W5QUuMLdkBFc5OTZUIWF1R2rH0pGhJvGB1jauBaJLdFzNZrzzz/f9gim3y+JI5RkxGqoIES24Ufj4t1+IYwWN6I9bNiwAq5vbg4nnmSQf/755+btt9+2JzjCB7jHKT31loc56tatawUbY4IscnpK4LmgtelNN91kPX+xXJF8xpzD+LzZvxAlAbk0lE97wzd4/LhA9SZdZlS4+fFROvPiiy/GFG0Hz3HVzHQwroTjNfUXItsWt996giMkqTRhCAKUaiWaBuYFiznV3g98Zo8++mjK22Sjra3Ibf6Jcc7hscvVSIWk/YRcIdOOjaviwiD2tM8++5gvv/wy5QMSIlctbpLnwmZxCyH+V/LJ79tdNHLPY1cKWizCTXs2GhokC+tSdylEtiGxCberd+JXrKvfWOuVJFiCdAYjpiuECBe1atWyBgO6+Msvv9h7HrM8VZI+Q3FCScUPz7re9oRCZAs387YwizvWeiWJN9GTpiBCiPBQunRpm/PFuceN7003XJe0xe3tMJUMnBRztX2j8D9+nHvtrrzlLhcifMyePdv2PSGBEvd4Uc4/6pwmchI/xridxR22kjAhhLHNgxBu+geQTU7FAz36XU+JYhNussW/+eabpNadM2dOygcjRElBjJsfjZ/gx8wxyeIWInxUq1bNijWWN9CCmV4SLOOWiiGRknAjxqkIcjpXEkKE1VVOkwWs6YkTJ8Zd58wzz7Q1zEy7clD7yTapNmkQQvgLNJGmT/QgoEkZeWD83mnRS1vmZPueJC3csQbcCxFUslHHTR//33//PWFJJZOsNmzYYPr16xdZVtg2QojggbWNlw0Bx5BIpZokaeHmql+IsODHGLeLc+NCE0KEk7y8PLNq1apI6SeeNNzolStXTnofSk4TOYkfO6c54U42j0QIERwY30lyGhY2CWokqzFJc+edd055XxJukZP41eJ23dO4KleOiBDhYc6cOTaOXbt2bTsFrygDjiTcIufgipe++361uOl/gBst3Vm9Qgj/wRyPTBkLEm6Rk9Y2+FW4Aatbwi1EsMnLy7P3eM843xDbZkoYfcrp1Ii7nN95qt41/wwjFqKEcNN4/OoqB9VyCxF85s6da9avX2//XrZsmY1xk0lOMhr3lIGxPFVkcYucw88WN8kqIOEWIvj8/fffVqABa7tBgwYF5nFTal29evWU9iuLW+Qcfra4+VEzoUxtT4UIPtttt53Np3F/x5rHnQ4SbpFz+NniBs3lFiIclC1b1l6Ec87ZbbfdzJIlS/LN4+Yxy1NFrnKRc/jZ4nYJahJuIYLP7rvvbv744w8zc+ZMW/6F9U2LU6xvl7jGcrxsqSDhFjmH3y1uhHvatGnZPgwhRBHBOCCu7WZwO7EuKhJukXMEQbg//PDDbB+GECJDcK7J5PlGwi1y1lVOHaVfY9zEvnCrFaW7khDCX6xbt85ml7vOjVWrVo1knaeCzgoi53A/Gr+2FMXiprtbOvWdQgh/QuOVpUuX2nannIPKly9vc1nokpgqEm6Rc/h1wEis7mlCiHCwfPlyU6dOHWtlYzSQkMZcbpqypIqEW+Qcfh0w4lD3NCHCed7ZOWoSGI9d6C4VJNwi5/C7xU07RGLbEm4hwtmMJe+/2eXEvL2d1JLFn9k5QuSwxb399tubGjVqqHuaECFi5513Nps2bbKxbdfHnJao9erVS3lfEm6Rk8LtZ4sb1D1NiHBR87+5K0C3NM5BZJRzoZ4qEm6RcwRBuNU9TYhwUdpzzkmnzakXCbfIyRi3c1f5WbgnTpyY7cMQQmQIWp8WRu3atZPal5LTRM4RBItbrnIhwsX2228f80Yi6l9//ZVSPbcsbpFz+D2r3Fnc1H2mUyoihPDnwBEvJKYh1tw4H7ky0GSQcIucw+9Z5d5EFjotCSHCwbZt22wHNSaEcVFeuXJlU79+/ZRLwuQqFzlHEFzlTrhVEiZEeNi0aZP9TZcrV87stddetuwznTpuCbfIObjS9bvFre5pQoSPsmXLWrFev369mT17tg2HuWmFqSBXucgp6FgUBIu7SpUq9kpcwi1EeChVqpTZdddd7Y2ENFzmc+bMsc1Z+M1XqlQpqf1IuEVOsWXLFnvvd+GmPSLucrnKhQgHy2JM+2O0MENHaH26cOFCCbcQsXBZ2n53lYNKwoQID5s3b477HN61VGLdEm6RU7h4kt8tblD3NCHCQ926dTO2LyWniZwiSBa3hFuI8OXYbNq0yZaEbdy4MTIlLFVkcYucIkgWN65yxbiFCAd///23+f33322eDecflySLJZ5qSZiEW+SkcAfF4iZpxSXUCSGCy5IlS2zyWbVq1WzyKdb2n3/+aZfThCUV5CoXOekqD4LF7ZqwcKUuhAg2f/31l50KhmgD99WrV7fLU0XCLXKKILnKnXCn88MWQvgLBopEzx7golzzuIUIWXIayOIWIvhUrVrVzJ8/3+yyyy72/MO5aOXKlbYZS6pIuEXOWdxulJ7fYWZ4xYoVE9Z/CiGCAQJNwxXvRDDanzJoJFUk3CKnCMJIz2irW65yIcJB5cqV0xLqaCTcIqcIwkjP6JIwucqFCAcbNmywNdyuFIwsczxrqeJ/f6EQGSQIA0aiLW65yoUIPitXrjQLFiyw2eSM9eSexyxPFVncIqcIwkhPLxJuIcLB8uXLbb02oz0duM0ZLkLCWirI4hY5RdAsblzlCHe6rRGFEP6A3zDjO73weNu2bSnvS8ItcoqgCTcW99atW+3cXiFEcKEcjNGe7iKcex6zPFXkKhc5RRBd5Qwa4ZbOD1wI4Q/Wr19vE02Jabte5Yg3fcp5zrHnnnsWui8Jt8gp+LGQGBIUXBMWho00b94824cjhEiTVOPYiZBwi5wiaHXcu+++u73XeE8hgk2VKlUyti8Jt8gpglbHzbHiSpNwCxF8/vrrL5uv4nJtCH/ttNNOKe9HyWkipwhachrww5ZwCxH85iu///67bbfM39Rxz5s3z/6dKhJukVMELTnNCTcxbiFEcCGDvHbt2rY/OeJNGKxu3bp2JneqSLhFTiGLWwiRDcgoj06M5XE6LY0l3CJnoNEBNdESbiFENvDWcMOmTZvSOh/5UrhxC5577rk2fZ7OMvvss4/59ttvI8/zpu+++27rauD5Tp06mdmzZ2f1mIX/CdIs7mjhXrp0qb3oEEIEE37H3vbFtDplPnf16tWDL9xk3B188MH2KmTcuHFm+vTp5sEHH8yXSn///febwYMHmyeffNJMmjTJuhs6d+6sns6iUDc5BNHiRrSJkQkhggmG5vbbbx/pUU61SMOGDU3FihWDXw42cOBAU6dOHfP8889Hlu2xxx75rO2HH37Y3HnnneaEE06wy4YPH26vWsaOHWvOPPPMrBy3CI5wB9HiBtzlrq5bCBEsvGVfrrFSuvjO4n7rrbfM/vvvb0477TRTrVo107p1azN06NDI86TP4zbEPe5gpumBBx5ovv7665j7JPi/bt26fDeRu67yIFrcoDi3EMHljz/+SOoWSIt77ty55oknnjDXX3+9uf32282UKVPM1Vdfba2kHj16WNGG6LgAj91z0QwYMMD06dOnwHJmoVaoUMHkCiRCUEeYS8fjfQ3nal6xYoXZsmVLkfdXXNsvWbIk38Qg8jjeeOMNez9x4sSY27jyklSOMdPrhQk/veeSOpZMvk5J/E4ysV2mfgPeXuPxcG7yjJDnM0qXLp3Xrl27fMuuuuqqvLZt29q/J0yYQDpe3uLFi/Otc9ppp+WdfvrpMfe5efPmvLVr10ZuCxcutPvg71xi/vz5ebl2PN7XmDNnTl7v3r3zVq9enZH9Fdf2I0aMKLBN7dq18+66666ktkn2GDO9Xpjw03suqWPJ5OuUxO8kE9tl6jeAlpSkpvjOVY7V0KxZs3zLmjZtaq1joHgdoovWeeyei4YkABIAvDeRewQ1Oc07JUwIEUxInt64cWOB8N3atWtTruX2nXCTUT5z5sx8y2bNmmXq1asXSVRDoD/55JPI88SsyS5v165diR+vCA5BLQeDWrVqqXuaEAHmzz//zFf5RN9yyphZ/ttvvyXlbvetcF933XXmm2++Mf379zdz5swxI0aMME8//bS54oor7PP0d7322mtNv379bCLbzz//bLp3724tkhNPPDHbhy8CYHHvsIPvUjtyxuJ+6aWXTM+ePW0CKp4wfs8vvPBC3PW5IKd6ZNddd7XrN2rUyPZw4KQXr5z0xhtvtDONWX+33XYzp556qvnll1/ivgaGwemnn25fgzyCli1bmhdffDHSJEOITMB31uvtZS43Zc6NGze2rVBTKff03RmsTZs2ZsyYMea2224zffv2tRY25V/nnHNOZJ2bb77ZuhwuueQSs2bNGtO+fXvz/vvvpzVlRYQTks/4bniT0NxIT8Qiej3qKv0s6GERbso4SfJBJAmLJUr4ISHvjDPOsEk9p5xyivW0TZgwwdxzzz3m008/tV43xNl7IsTrhhXDPYJPot/rr79ue0KwDdUnXugTcdBBB9mTKuLN5/zuu++au+66y1pCjz76aLF+HiJ32LZtW74wHRrmysJIkk42oxx8eaY69thj7S0enHgRdW5CxAJB5kROtnWikZ5uvfLly/tauHGVkw1PLMwrVkHjmWeesVYzoa/77rvPXqDHAiG99NJL7W8dsd5vv/3scqzgq666ygwZMsQ89NBD5tZbb41s06tXLyvaVKTQtMlBmeghhxxiLrjgAuuh834nLrvsMhtjfO+990yXLl3sMi4MWP+xxx4zZ599tkJwIiPwvXOzEjAi+Lts2bKR77XXoCh0X5k5JCH8TxAHjDjclTkWZJCh/4LLV0kEZW/Lly+34S8n2sDJjTAZ0DnR685+88037ckxuvQT4T3uuOOsdf3555/nc5F/8cUX5vDDD4+INnBxh/iDt4eEEEUB4wCvGTlZ5KvQ8dOViHGhmkrujYRb5AxBHOkZLdxhcJcng+vJ4O2a6CCsQWwQNzt9H7zb4ILnBBmN2w/ucsf48ePt/VFHHRUzZMeJ1Sv0QhQFQj1caOIS5x4vmhcajiWLf32DQmSYIFvc7keeK8KNALtOidHg2iYJzVnN9Ht225Dgs2HDhgLi7fbD+g43mAjXfTRYQog9VjrhFD+HUUQw4DtUv379mM9Fj/ssDFncImcIsnDT1peM51wpCaMslAxc5g9MnTo133NklTtILHTg7iYBKNpVTmb6O++8U2B9LgDcZxsLXp/9pVKmI0Qi+D7xvSMMxL23Q2Iq6DJShBYmamEtudpJ7rGkvLWUJHsFYVwmsV3c5bki3FjMgwYNMhdddJGNUVPShauR2Pd3331nmjRpYmbMmJEv0YxkVapLHnjgAZuQ1rZtW5sTMHr0aNvU6aeffsq3vhAlCecaxnjyWyZkh9eI8A5WeKoJpxJuEVoot+Dm3JxYTvxgvCVIxL2DMg6W2mTEKle48MIL7cUKY3xJPOMCi9gzZWBMEeSz8MYFqYVltgHZ5ZR/TZ482U4aRNA5OTI50Lu+s7Sd5R0NSUScZHNpnoEoPriIJD/DO2eDkkPEO5mETS8SbhFaiBtRbuF+FFjb/HC8PxKugoNixe67775m2LBhJpfA/e3N+HZ069bNWs98JtG5AJScRdO7d297T+MXh4ttu1i3Fy4SiIsT51Z8W2QCMsfr1q2bbxkNgqI7hSaD/EYitCDUWNg05uHGydj97W64qDI6tacYoSyK5LR4U/ByBeq6cTkeffTRcePTXvh/HzVqlBVgGrk4Dj30UHv/4YcfFtgGyx1vjVtHiEwQXaudSu22Fwm3yBmCnJwGrp6ZGG8ugKs6Gi5ciHsjwjRKif7/jW6FSvIPLVCxamjc4srqYK+99jIdOnQwn332mXWte8MnxNeB1xIiUx7A6CEjjAtNNaMc5AMSOUOszmlBAhd/1apVzffff2+6du1qgghu7K+++sr+TRczt8zVVNO+2Inl4MGDbW9zlhGbXrhwoY11c7J79tlnC7jJiRfuvffeti4bFzcC/MEHH9hYOJ/XgAEDChzP448/bjPYafRCe1XasNLylN7mV155pW2HKkQmiHaTA6It4RYiAa5XeVDBrYZYBdniRrSj4/S4vrk5nHAjmjRAefvtt20G7i677GKOOeYYc8stt5jWrVsX2Dduc/qTsy/Kv/i/bt68ue1+RrvTWBnlCD3lYvRQR7CxiBj6gDV/xx13FMtnIHJ7OmEsUjUoJNwiZwi6q9y5y19++WUTVJgElmgamJeOHTvaW7KQ/T18+PCUjwmX+WuvvZZvGZUH6cYfhYiFt/lPNFxgpoKEW4QSYqBYaK7UhwSl6Ok83vWCkjmMcFMKRYewVFokCiGyS9OmTQsYEvyO0yk3VHKaCCUIMS0wnSC7WdyxhNu7nt/JtQQ1IcLC9ttvn+9GVQvli3RRSxUJt8gJ4gl30CDpigEbEm4hgg/hGDyB3il3yRAMM0OIDAl3kLPKvQlqZJYLIYINCZO0700VCbfICcJicQPC/corr2T7MIQQKTBt2rRCk9OYRkdf/cKQcIucIEjCTexr5MiR+eq3Ga7hoNcxtceUVTkPAtsIIfw9a6AwGjRokNS+JNwip2oogyDcJ510UoHSJG8jkDlz5thuYD169DCdO3fOwhEKIVIlmYvrZC/AJdwiJwiSxV0YDRs2tM1GSFCTcAvhXyj3SoZUSzsl3CInCJNwh6GDmhC5wGbPyGAyxzds2GDDW5yHOCfhCWT2fKpIuEVOECbhdvXc0d2+hBD+7U/O+GB64TNvwLFq1aoCg3GSQXXcImeEm6YHsfpVBxEsbmLfK1euzPahCCGSgC6O9GDwwmPX3TEVwnEWEyIH+pTH6qCmem4hggHdGXGVe1m/fn1aXRvlKhc5AbGkoDdfiS4toccxce4jjzwy24cjhCiEGjVqmAULFtgxnpyLOCcxja5OnTomVSTcIicIm8WNy18JakIEh4oVK5pGjRqZNWvWmC1btpiyZcuamjVrpmVQSLhFThA24Xbu8jFjxmT7MIQQSYJIR5d+kafChMJUkHCLnCCswj1o0CCbmerNVBVC+A9c4/xWsba9kJzmMstr166d1L6UnCZygrAKN0ydOjXbhyKEKATi23///XeB8Z7g/TsZZHGLnCCMwk28jOYNxLmPOOKIbB+OEKKQc1CsfuWrV6+29d2pIItb5MyPJkxZ5S5BrXXr1kpQEyIAxDMc0jEoJNwiZ4Q7nXrJILjLJdxCBHc6GJ6zVJFwi5wgjK5yJ9y//fabLTERQuQGEm6RE4StAYtDHdSEyD0k3CInCKvF3bhxY9uJScItRO4g4RY5QViFmxKSVq1aKc4tRABh1Oe6detS3i582TpCxPhxhFW4nbt83Lhx2T4MIUSSbNq0yeal0HyFi2/aoaaCLG4RerZu3WrFO8zCPXv27LTGAwohSi7PZtmyZWbWrFl2JC/Uq1fPhrtSRcItQg/WNoRZuEEd1ITwLwg208CqV69umjRpYgeMMGgkHSTcImeEO4xZ5cBJgBOA4txC+Bd+o7jI8YwxhxsvYLooxi1CT9gtbpegpsxyIfxLgwYNrLucFqdLly41ixYtMpUqVTKVK1dO2fKWxS1CDz+WMAs3aDa3EP4Hrx+ucuLaxLexuufPn5/yfiTcIvSE3eJ2cW5iaLjghBD+Byu7Vq1aNtSVKhJuEXpyRbi5eleCmhD+5I8//jCbN2+OOSyI0rBULrol3CL05IJwN23a1Oy8885ylwvhUxBn3OKxxJs8leXLlye9Lwm3CD1hzyoHJp+1bNlSwi2ET8GyrlatWkzxpm3x33//nfy+iuH4hPClcIdxrKcXjfgUwt9UrVrVJqch3n/99Ve+57bbbruk9yPhFjmRVY6bPJUfRlAzy2fOnGm2bNmS7UMRQsShSpUqpkaNGmbevHlm5cqV1vpevHhxSiVh4TZBhAjxgJF4CWrpDC0QQpQc1G7jAVyyZIm9Idp16tRJensJtwg9uSLczZo1MzvuuKNNghFC+ItGjRrle1y+fHm7jIvtVL2BcpWL0JMrws17JEFNw0aE8B/xzkHphPAk3CL05IpwO3e5LG4h/AcDRjKFhFuEnlwT7g0bNmT0JCGEKDpulGcmkHCLnBDuMNdwx0pQ+/HHH7N9KEKIqByUTCHhFqEnlyxuTg40elA9txDhRcItQk8uCTeehYoVK0q4hfAZ1G0TxorFqlWr7LjPZJFwi5xpwJJLNaISbiH8BXknCxcujCnelHEi3ski4RahJ5csbqhUqZKZPn262bRpU7YPRQjxXwhh1a5dO6Z4MyBIvcqFyGHhxuLetm2bEtSE8BkVKlSwHdIQb+8YTxJKEfZkkXCL0JNrws3Jgff7/fffZ/tQhBBR0DHNiTftTmlRzN/8bpNFwi1CT64JN1fu++yzj+LcQvhYvBs0aGDzbxBv5nEzeCRZ1KtchBpcULkm3K6ee9KkSdk+DCFEnDrunXbaydSrV8+kgyxuEWq2bt1q73OlAYtXuH/55ZcCM3+FEMFHwi1CjZtNnYsWNxctP/30U7YPRQiRYSTcItTkqnAT4+Y9K84tRPiQcItQk6vCTUOH5s2bK7NciBAi4RahJleFG/bdd19Z3EKEEAm3CDW5LNzEuadNm2Y2b96c7UMRQmQQCbfICeHOtaxyJ9y8/59//jnbhyKEyCASbpET5WC5aHG3aNHC7LDDDnKXCxEyJNwi1OSyq5wGD3vvvbeEW4iQIeEWoRfu7bbbzrYUzEVwlyuzXIhwIeEWoRdurG3EO1eFmxh3KiMDhRD+RsItckK4cxVKwujVTna5ECIcaMiICDW5KtxjxoyxZWAk55199tnmo48+MrNmzcq3DgMOJk6cGImHn3TSSVk6WiFEKki4RajJVeFGtM866yz79/3332/HCN5666351vn999/NQQcdZP8eOXJkVo5TCJE6cpWLUJOrwh0d51ZmuRDhQcItQg2u4lxsvhIrQe2ff/7J9qEIITKAhFuEGlnc/y/ciDbzuYPCSy+9ZHr27Gn2339/OzCFqoAXXngh7vqTJk0yJ5xwgtl1113t+o0aNTJ333133Hnkq1evNjfeeKPZc8897fq77babOfXUUwv9jMaPH29fp1q1ana7OnXq2NyAH3/8scjvWYhkUYxbhEag16xZYypXrmy7hXmXE99NZt2w0rJlS1OqVCnrLm/durUJAnfeeaeNwSPEu+++u/07Hm+88YY544wzbK3+KaecYmrUqGEmTJhg7rnnHvPpp5+aTz75xIqsY+XKlaZdu3Zm9uzZ9h4hXrJkiXn99dfNuHHj7DbsI5p7773XHlfNmjXNiSeeaI/tzz//tK+FR4PPWYiSIPxnLZETIMackBHpaOGOtrjjrRtWypYta5o2bWqF+6KLLjJB4JlnnrFWM5nv9913n7nttttirodFfemll1qLHAHFuwB5eXnmqquuMkOGDDEPPfRQvsS8Xr16WdG+/vrrzYMPPhhZ/vXXX5tDDjnEXHDBBeadd97J9zpvvvmmFW0Ee8SIEWbnnXeO2aFPiJJArnIRauQqD2aCWqdOnaxoFwblbMuXL7eC6kQbEPJ+/frZv5988kkr5F4RxgPRp0+ffPvC+j7uuOPM9OnTzTfffJPvOYS/QoUK1l0fLdqQCxeAwj9IuEWokXD/P4jaTz/9ZJuxhImlS5fa+z322KPAc4RCqlSpYt3sc+fOzbcNbu7oEIp3P1jfDuLXM2bMMEceeaTdBnf6wIEDzaOPPqrYtsgKukwUoUbC/T/hpu0pyVetWrUyYQEBhnnz5hV4bu3atTYJDWg+07Bhw8g2y5YtMxs2bCgg3m4/XqF3noqqVauagw8+2CbCeTnnnHPMc889l/PVC6LkkMUtQo2E+/9BrHEfh23gCEJasWJFM3bsWDN16tR8z5FV7iAZ0dGlSxezbdu2Aq5yBNnFttetWxdZjsjD888/b3MjSF5bv369/Sxxr7/88svmrrvuKrb3KEQ0Em4RqpptrEq6hrmbmw7mXcY6bk53rlCuXDnTpEmTQMW5kwGLedCgQTYEgIiee+65tsyLjnDEtnnPQEzb0bdvX5up/sADD5j27dvb9bGaO3ToYJo1a1ZgfUTe3b/yyivm8MMPt69Lhj4XDPz92GOPaZCLKDHkKhehYePGjWbBggURlyUnWm5YT95yImqaEfBco0WLFjbxKmxceOGFtkSL1q4knnFR1qZNG1sGRiya+DR1147atWubKVOm2Oxy4tWTJ0+29dgIev369c2ZZ55pdtlll8j6lSpVimzH0BYv7Ldt27bm448/Nr/++muowhDCv0i4Raisylq1akVqdp27s27duvkylLGMFi1aZHINrMiwjjfF/c0tmm7dutn3HS24fE8oOYumd+/ekYscx1577RVJdouFWx6v2YsQmUbCLUIDDTgQbSZdAfFIwHpyy7zr5hpcsORSAhV13fPnzzfHHHNMxGpOBJb6qFGjbGmX9yIAi5oSMBLW8NREf5ecFwNrXYiSQDFuEVpIIIJYZT+5CCECbwexsOBNJHMsXrzYNptBhOmg5oV4eLR1TEiFWPfMmTNt45bq1atHnuP7g+VOKMbVhjtefPFFK9zEyombC1ESyOIWoRZuXMO40MX/W9zJWJ5+ADf2V199Zf+mnahbRq9wQChdF7jBgwfb3uYsI+a8cOFCG+vetGmTefbZZwu4yWlTuvfee5ujjjrK1m1zQfPBBx/YWHjXrl3NgAEDIvXhjv79+9vXpu0px0UPdbqvvf3227ZW/KmnniqhT0YICbcIMdTp4uIMa1w3zBY34jhs2LACrm9uDifcZJB//vnnVkSp2yY0gnv8lltuidmbnYsX+pOzL8q/KBds3ry5GTp0qG136s0od7BPmrJQQjZmzBjbsY26brLYiYs3aNCgWD4HIWIh4Rahtrjp0y3+Z3EHRbhpLZpoGpiXjh072luy0Lp0+PDhKR8TQv3II4/YmxDZRDFuEQqIZWIVeXtGO4s7mXVzxeLOpeQ0IcJKbp25RGhBhF37S6/FHSumG2vdXCBIFrcQIj6yuEVoQbhjWdy5iixuIcKBhFuEEsp7KN9RjPt/yOIWIhxIuEUoIb4NsrhztwGLEGFFwi1C3XxFFncwy8GEEPFRcpoIJblucdOWc+TIkfmW0VyErmFuOf3bqUd26wshgoGEW4S6a1quCtJJJ51UYFn37t1tl7GzzjrLPmZiGs1LhBDBQq5yEVrhpsd0rC5YuZqsx2xyucqFCD46q4nQuso1XCR/fBuUnCZE8JFwi9Ba3LS2FP/LKAdZ3EIEHwm3CCWyuGMLtyxuIYKPhFuEElncsV3lsriFCD4SbhHarmkS7v8hi1uI8CDhFqED0c7Ly5Or3IMsbiHCg4RbhLZrmizu/6HkNCHCg4RbhLZrmoT7f6gcTIjwIOEWoe2aVq5cuWwfim+QxS1EeJBwi1AKN6Ktrmn/Qxa3EOFBZzYROlQKVhBZ3EKEBwm3CB1qvlIQlYMJER4k3CJ0yOIuiMrBhAgPEm4ROmRxF0SuciHCg4RbhK5rGsItizu2xV26dOlsH4oQoohIuEWo2LRpk+2aJuEuaHET36ZMTggRbCTcIpRd0+QqL2hxKzFNiHAg4RahQu1O41vcim8LEQ4k3CKU7U5lcedHFrcQ4UHCLUKFuqbFRha3EOFBZzcRKlTDnTg5TQgRfCTcIlSoFCy+q1wWtxDhQMItQmdxK75dELnKhQgPEm4RKiTcsVFymhDhQcItQgONVzZu3ChXeQxkcQsRHiTcIlRd02h5KuEuiCxuIcKDhFuEBjVfiY8sbiHCg4RbhAa1O42PysGECA8SbhEaJNzxUTmYEOFBwi1CVcNdtmxZs/3222f7UHyHXOVChAcJtwgN6poWHyWnCREeJNwiNKhrWnxkcQsRHiTcIjSo+Up8ZHELER4k3CI0yFUeH1ncQoQHCbcITdc0XOWyuGMji1uI8CDhFqFAXdMSI4tbiPAg4RahAGsbJNyxkXALER4k3CIUqN1pYuQqFyI8SLhFKFDXtPgQQtiyZYssbiFCgoRbhEa41TUtvrUNsriFCAcSbhEKlFGeOL4NsriFCAcSbhEKVMMdH1ncQoQLCbcIBWp3Gh9Z3EKECwm3CAVqdxofWdxChAsJtwhN1zRZ3LGRxS1EuJBwi8Dz119/ma1bt8rijoOEW4hwIeEWgUfNVxIjV7kQ4ULCLQKP2p0mRha3EOFCwi0Cj7qmJUYWtxDhQsItQiHcO++8s9lhhx2yfSi+RBa3EOHCd8JNktFdd91l9thjD3sybtiwobnnnnts5rCDv++++26z++6723U6depkZs+endXjFtlDpWCJkcUtRLjwnXAPHDjQPPHEE+axxx4zv/76q318//33m0cffTSyDo8HDx5snnzySTNp0iRTrlw507lzZ7N58+asHrvIDioFS4wsbiHChe98ixMnTjQnnHCC6dq1q31cv359M3LkSDN58uSItf3www+bO++8064Hw4cPN9WrVzdjx441Z555ZlaPX2RHuKtWrZrtw/AtEm4hwoXvLO6DDjrIfPLJJ2bWrFn28Y8//mi++uor06VLF/t43rx5ZunSpdY97qhUqZI58MADzddffx33xLVu3bp8NxEe5CpPzlVeunTpbB+KECKMFvett95qhbVJkyZ2RCMx73vvvdecc8459nlEG7CwvfDYPRfNgAEDTJ8+fQosX7BgQU65WDdt2mR+//13E6bjwQPD9+Xff/+Nua9Mv+ei7i+d7VPZZsmSJdayXrRoUWQZXqs33nijwIUt+SGsT65Ipo856PjpPZfUsWTydbLxO0lnu2TXL2w9V9mSs8L96quvmpdfftmMGDHC7L333uaHH34w1157ralZs6bp0aNHWvu87bbbzPXXXx95zIm+Tp06pm7duqZixYomV+CLV69ePROm46Fr2rZt2+x+Yu0r0++5qPtLZ/tUtiHUhNfKu/5DDz1kkzmjTy7sl/Xbtm2b8WMOOn56zyV1LJl8nWz8TtLZLtn1C1uvpL24vhPum266yVrdLla9zz772A8NqxnhrlGjhl3+559/5rMUeNyqVauY+8QCUXwvnKiGu3AIFen7L0R48F2MG5dEqVL5DwuXOVYVUCaGeBMH917tkF3erl27Ej9ekV3U7jS5GLdKwYQID74T7uOOO87GtN99910zf/58M2bMGDNo0CBz0kkn2ee322476zrv16+feeutt8zPP/9sunfvbl3pJ554YrYPX5QwancaPov7pZdeMj179jT777+/PW5+8y+88ELc9blop8Jk1113tes3atTIhgYIo8Ri9erV5sYbbzR77rmnXX+33XYzp556qvnll19irn/YYYfZY4h1I39AiJLGd65y6rVpwHL55ZebZcuWWUHmR8wP0XHzzTebjRs3mksuucSsWbPGtG/f3rz//vtmp512yuqxi+Jjy5Yt9v+6cuXK+TqkYXHz/+5d5l1XBM/iptST8BhCTDgsUVIQSXdnnHGG9cqdcsop1hs3YcIE27Tp008/tZ4570XLypUrrWeOhk3cI/gk6L3++utm3LhxdhsqVGLRq1evAsv0HRPZwHfCjeVEnTa3eHCl27dvX3sTuQFizEmXWHa0cEdb2951RfAs7meeecZazSQD3XfffTa5NBZY1Jdeeqk9HyDW++23X6TS4KqrrjJDhgyxiXnkzHjFF9EmWfXBBx+MLCfj/pBDDjEXXHCB9eLFonfv3hl/r0KEwlUuRKqucgl0uISbHg3JZPqSEb98+XIbInOiDQg5oTSgu6K3XfKbb75pc2iiy0OxvgnTTZ8+3Xz++ecZfT9ChN7iFiIVsLirVKmS7cPwNUFzlSeL69tAwmosFzbfC9zsc+fOtTMP3Da44GNd7Ln94C5v0KBBgecpUSXvpmzZsraCpUOHDgUSaYUoCSTcIvAWNzX5IjwWd7IgwK6bYjRr1661SWhAF0Yn3GxD7kwsT43bj+vaGI1rAuVo3Lix7TlBEp0QJYkuF0VgwQUaK8YtcsPiPvjgg20DJWYUTJ06Nd9z3mRWEhUdtE6mtDTaVU5m+jvvvFNgfSCBjefoRke5Ku70a665xvz222/myCOPtB0YhShJZHGLwED7WzcwA5gGRyIa1qR3MhzrsK4It8WNxUyp6EUXXWRj1JR0kVVO7Pu7776zbZNnzJiRz51NQisVKA888IBNSKNrHFnlo0ePNs2aNTM//fRTAff3ddddl+9x06ZNbfIsFw1kr7MvphUKUVLI4haBgRJArBviltycaxMLyS3jxjqsK/4frET6koeRCy+80Lz33ntWuEk8e/zxx+0wFcrAqNOGatWqRdavXbu2mTJlit2O7w+C+80331hBv/322wusnwjKVIGMdiFKElncIjAwd71WrVoR69F1TeNE681CxsL0DtnIdegs6GK8YQT3t5se6KVbt27Wet53333zLec7RMlZvHKvZGPWu+yyi81g10WiKGkk3CIw0GQD0XaNdpgIBsRvo5vvsK4wkQucXBqm46xgMsCPOeYYO/a3MAitjBo1yvYIoJGL+24lYvLkyTbPQt3TREkjV7kIPN46XVGQMCfwxZrKtHjxYhv3RoSJQXtBkKNboZKsRgvUmTNn2sYtdGt04E5ftWpVgdfAo0N3Rzj77LMz+I6EKBxZ3EKEHMQtSMKNG/urr76yf7suZiwbP368/ZsWxwgzEKOmtznLCJksXLjQxrqJ6z/77LMF3ORMEWRc8FFHHWXrtsm4/+CDD2wSW9euXe0UQi80Y7nssstsVzXWpzYcMWeWAi5ySsRwyQtRkki4hQgxWJPULAfJVY5oDxs2rIDr25sE5oSb2eOI69tvv23rtok74x6/5ZZbTOvWrQvsG7c55V3sixIvEtmaN29uhg4datudRmeUI/ynnXaazVInqY3PkuYulKKxPn3ShShpJNwisJAYJBLjEqeCZHEzCSzRNDAvHTt2tLdk4XMYPnx40uu3aNEipfWFKAkU4xaBgHgl1pR3wEi8GHeidXMNFwMOknALIRKjM5sIBIiwa3GZyXXDjiuZC5KrXAiRGFncQuSAcMviFiI8SLhFYFGMu3DkKhcifEi4ReBRHXd85CoXInwoxi1EiKCDHM1BGLQBf/zxhznrrLNsrXJ0qRNtYqM7zgkh/I+EWwQWucoLctJJJ9lBK9Q3w5AhQ8zrr79uRowYUWBd73pCiOAgV7kIPHKV52a7UyFyFQm3ECEmaO1OhRCFI+EWIsTk4mQwIcKOhFsEFsW4C0euciHCh4RbBB7FuOMjV7kQ4UPCLUSIkatciPAh4RYixMjiFiJ8SLhFYFGMu3BkcQsRPiTcIvAoxh0fJacJET4k3EKEGLnKhQgfEm4RWOQqL9wTsWHDBrnKhQgZEm4hQsqmTZvMtm3bZHELETIk3CLwKMYdG83iFiKcSLiFCCmaxS1EOJFwi8CiGHdiZHELEU4k3CLwyFUeG1ncQoQTCbcQIRduWdxChAsJtxAhRa5yIcKJhFsEFsW4C7e4d9hhB7PTTjtl+1CEEBlEwi0Cj2Lcidud6gJHiHAh4RYipKjdqRDhRMItAossycRoMpgQ4UTCLURIkcUtRDiRcIvAoxh3bGRxCxFOJNxChBTN4hYinEi4RWBRjDsxcpULEU4k3EKEFLnKhQgnEm4ReBTjjo1c5UKEEwm3CCxylSdGrnIhwomEW4iQeiHkKhcinEi4ReCRq7wgf/31l9m6dassbiFCiIRbiBCikZ5ChBcJtwgsinEXLtxylQsRPiTcQoQQzeIWIrxIuEXgUYy7ILK4hQgvEm4hQohi3EKEFwm3CCyKccdHrnIhwouEW4iQWtylSpUyZcuWzfahCCEyjIRbBB7FuON3TZNXQojwIeEWIoSoT7kQ4UXCLUQIUbtTIcKLhFsEGrmCY6MBI0KEFwm3CDyKcRdEFrcQ4UXCLUQIUYxbiPAi4RYihMhVLkR4kXCLwMe45SoviFzlQoQXCbcQIUQWtxDhRcItRAhRjFuI8CLhFiKEyFUuRHiRcItAoxh3QbZu3Wr+/fdfWdxChBQJtxAhY8uWLfZeFrcQ4UTCLUQILW6QxS1EOJFwi0CjlqcFwU0OEm4hwomEWwQexbjzI1e5EOFGwi1ESIVbFrcQ4WSHbB+AECJ9xowZYzZv3pxvWfXq1c1ZZ51lPvnkE7PDDvl/4jvttJM56aSTSvgohRCZRMItAk2ul4Mh2oi0ly+++MKMGjXKvPTSS6ZUqfxOtZEjR5bwEQohMo1c5UKE0FVevnz5AqIthAgH+mULEULhVnxbiPAi4RYihMIdtIxy3Po9e/Y0+++/v9lxxx1tCOSFF16Iu/6kSZPMCSecYHbddVe7fqNGjczdd99t/vrrr5jrr1692tx4441mzz33tOvvtttu5tRTTzW//PJLUsf3yiuv2GPiRhhCiGyiGLcIlCCtWbPGVK5cOZJ0FSvG7V0vFwmixX3nnXea33//3Qrx7rvvbv+OxxtvvGHOOOMMs/3225tTTjnF1KhRw0yYMMHcc8895tNPP7VJeYizY+XKlaZdu3Zm9uzZ9h7BX7JkiXn99dfNuHHj7DYHHnhg3NdbunSpueKKK0y5cuXMxo0bM/7ehUgVWdwiUILESdiVOxV1vbASRIv7mWeeMfPnzzfLly83l156adz1sKh5ngs2xPrll182Dz74oPn666+tuLLsoYceyrdNr169rGhff/31ZuLEiXb9ESNGmPHjx5u///7bXHDBBWbbtm1xX/OSSy6xF0KJjkuIkkTCLUTICKLF3alTJ1OvXr1C10N4EfcTTzzR7LfffpHlCHm/fv3s308++WQ+L8ybb75pE/X69OmTb19Y38cdd5yZPn26+fzzz2O+Hu76t99+215YkPAnhB+QcItAo5an4RDuZMFtDXvssUeB5wiNVKlSxbrZ586dm28bXPCxhNftB3d5NAsXLjTXXnuttbiPOOKIDL8TIdJHwi0CTy7XcYfFVZ4sCDDMmzevwHNr1661SWgwa9asfNusWLHCbNiwocA2bj/e9d136sILL7Sf4wMPPJDx9yFEUZBwCxEywjyL++CDD7ZiOnbsWDN16tR8z5FV7iA50dGlSxcbw452lZOZ/s477xRY32W5f/TRR2bo0KGh/SxFcFFWuQjcyEoSiqKFytv2k+fdaMtcJMyuctzdgwYNMhdddJGNUVPSRVY5se/vvvvONGnSxMyYMSNf85m+ffua999/31rOJLG1bdvWZpWPHj3aNGvWzPz000/51sfNPmDAAJu01rlz5yy9UyHiI+EWgYJynAULFpgyZcrYx1hSWEve8qF//vmnQP/uXIKLlrC6ygEXds2aNc39999vE894v23atLFlYAMHDrTCXa1atcj6tWvXNlOmTLHZ5ZR/TZ482dSpU8cKev369c2ZZ56Zb33nIucCQQg/IuEWgYJa2lq1akXqdHv06GHKli1rdt5553wW96JFi0yucuihh1orNMzg/uYWTbdu3az1vO++++ZbzneGzPBoevfube9p/OLABU+8PF4fAHrDc6PsjOQ1IUoaCbcIFDTdQLSZcuVOyPHWy1VwJ++yyy4m16CGm1rwY445xlSqVKnQ9bHU6YJGMx8auTi6d+9uli1bViAL/fvvv7eifvjhh5sGDRqY5s2bF8v7EKIwJNxCiECxbt26AqGAxYsX27g3IkwHtegcCOL+Xq8MIRZaoM6cOdNcd9111vXuGDx4sA29RNeVY50j3JSH4V4XIltIuIUQWQc39ldffWX//vnnnyPL6G4G7du3t8LshJWsb5YRm6bemlj3pk2bzLPPPlvATf7nn3+avffe2xx11FG2bpsciA8++MDGwrt27WoT0YQIEhJuIUTWQbSHDRtWwPXNzeGE+6CDDrKdzuhoRt02YQHc47fccotp3bp1gX3jNqc/Ofui/Kt06dLWzU2pF5njGn8qgoaEWwiRdWgtmmgamJeOHTvaW7JQGjd8+HBTVHCVu2Q2IbKJLjVFYCB+iXXlJoMVdT0hhAgiOrOJwIAQu5aXmVhPCCGCiCxuIYQQIkBIuIUQQogAIeEWQgghAoSEWwghhAgQSk4TIsDQ+nXkyJH5ltHxi2lZ8dYXQgQbCbcQAeakk04qsIx2nTQpEUKEE7nKhRBCiAAh4RZCCCEChIRbCCGECBASbiGEECJASLiFEEKIACHhFkIIIQKEhFsIIYQIEBJuIYQQIkBIuIUQQogAIeEWQgghAoSEWwghhAgQEm4hhBAiQEi4hRBCiAAh4RZCCCEChIRbCCGECBASbiGEECJASLiFEEKIACHhFkIIIQKEhFsIIYQIEBJuIYQQIkBIuIUQQogAIeEWQgghAoSEWwghhAgQEm4hhBAiQEi4hRBCiAAh4RZCCCEChIRbCCGECBASbiGEECJASLiFEEKIACHhFkIIIQKEhFsIIYQIEBJuIYQQIkBIuIUQQogAIeEWQgghAoSEWwghhAgQO5gcJC8vz96vW7fO5BLr16/31XsuiePJ9GsUdX/pbJ/qNsmun+n1woSf3nNJHUsmXycbv5Ns/lbcc05bipucFO6VK1fa+zp16mT7UIQQQoRIWypVqlTsr5OTwl21alV7v2DBghL5kP1CmzZtzJQpU0wuHU+mX6Oo+0tn+1S3SXb9ZNbDkuACd+HChaZixYomV/DTb6WkjiWTr5ON30k2fytr1641devWjWhLcZOTwl2q1P+H9hHtXDoZbb/99r56vyVxPJl+jaLuL53tU90m2fVT2S/r+em7k0u/lZI6lky+TjZ+J374rThtKW6UnJZDXHHFFSbXjifTr1HU/aWzfarbJLu+374PfsJPn01JHUsmXycbv5Nc+q1sl1dS0XQfgfsPaxv3hl+uqoXwI/qtCOG/30lOWtw77rij6dWrl70XQsRHvxUh/Pc7yUmLWwghhAgqOWlxCyGEEEFFwi2EEEIECAm3EEIIESAk3EIIIUSAkHAngG5Rhx12mGnWrJlp0aKFee2117J9SEL4lpNOOslUqVLFnHrqqdk+FCF8xTvvvGP22msv06hRI/PMM88UeX/KKk/AkiVLzJ9//mlatWplli5davbbbz8za9YsU65cuWwfmhC+Y/z48XYYw7Bhw8zo0aOzfThC+IItW7ZY4++zzz6ztd7oyMSJE80uu+yS9j5lcSdg9913t6INNWrUMLvuuqtZtWpVtg9LCF+Cd6pChQrZPgwhfMXkyZPN3nvvbWrVqmXKly9vunTpYj788MMi7TPQwv3FF1+Y4447ztSsWdNst912ZuzYsQXWGTJkiKlfv77ZaaedzIEHHmg/xHT47rvvzNatWzVRTASSkvytCBEmvijib2fx4sVWtB38vWjRotwV7o0bN5qWLVvaDy0Wr7zyirn++uttR5vvv//ertu5c2ezbNmyyDpY1M2bNy9w48N2YGV3797dPP300yXyvoQI6m9FiLCxMQO/nYyTFxJ4K2PGjMm37IADDsi74oorIo+3bt2aV7NmzbwBAwYkvd/NmzfnHXLIIXnDhw/P6PEKEbbfCnz22Wd5p5xySsaOVYig/3YmTJiQd+KJJ0aev+aaa/JefvnlIh1HoC3uRPzzzz/Wvd2pU6d8I9d4/PXXXye1D/6fzjvvPNOxY0fTrVu3YjxaIYL9WxEiF/knid/OAQccYKZNm2bd4xs2bDDjxo2zFnlRCK1wr1ixwsakq1evnm85j8kQT4YJEyZYNwgxDdyE3H7++ediOmIhgvtbAU5Wp512mnnvvfdM7dq1Jfoi9KxI4rezww47mAcffNAcfvjhVkNuuOGGImWU230WaeuQ0759e7Nt27ZsH4YQgeDjjz/O9iEI4UuOP/54e8sUobW4Kd3afvvtbR22Fx5T2iWE+H/0WxEiWL+d0Ap3mTJlbKH7J598ElmG9czjdu3aZfXYhPAT+q0IEazfTqBd5QT658yZE3k8b94888MPP5iqVauaunXr2hT9Hj16mP33398mCDz88MM2tf/888/P6nELUdLotyJEiH47eQGG0hPeQvStR48ekXUeffTRvLp16+aVKVPGpu1/8803WT1mIbKBfitChOe3o17lQgghRIAIbYxbCCGECCMSbiGEECJASLiFEEKIACHhFkIIIQKEhFsIIYQIEBJuIYQQIkBIuIUQQogAIeEWQgghAoSEWwghhAgQEm4hRNYYP3682W677Uzv3r2zfShCBAYJtxA+Zv78+VbYom/lypUzLVq0MH369LFDEDLFAw88YPc/bdo0k03q169vb0KIgqhXuRA+F+499tjDNGzY0Jx77rl2GT/Z5cuXm3Hjxtnn27Zta7766is7F7ioHHLIIWbJkiX5piEVJ5s2bTILFiywc425OZxo8/6EECEa6ylErrDnnnsWcCf//fffdubvN998Yz7//HPTsWPHIr0GFwMTJ0401157rSkpypYta5o0aVJirydEGJCrXIiAsuOOO5rDDz/c/r1ixYp8z2GBH3roodalvssuu5gzzjjDLFy40Bx22GHWFR6Ld955x2zbts2ccMIJkWWsyzbJurPPO+88uw0ziwcPHmxFmeOsV6+edeuz/0Qxbhca+P333+3NGx5QHFyI/0cWtxAB5Z9//okIX6tWrSLLP/nkE9OlSxdTqlQpK9g1a9a0yw4++GBTpUqVuPsbO3asdVezXlG56aabrBfg2GOPNZ07d7b7Rng55nvvvTfudpUrVza9evUyDz/8sH3stf7jXUAIkWtIuIUIAMScncVJjBsL+4MPPjCLFi0y999/v2ncuLF9Dov2kksuMVu2bDFffPGFad++fWQbYuQjRoyIG2v+6KOPrNBnIlb+/fffm59++snsvvvu9vFdd91lGjVqZB599FErzGXKlIkr3LzPF154wT6WlS1EQSTcQgSA3377zbqao8Gi7dSpUz4X+dy5c81xxx0XEW3AKu/fv7955ZVXzNatWwvsB9H+66+/8rnJiwJC7UQbsOTZ97Bhw8zMmTPNPvvsk5HXESIXUYxbiACAuxmr2d2wuN98801btoVre9KkSXa9H3/8MZIdHg1x5jp16sTcP/vaeeedzVFHHZWR491vv/0KLKtdu7a9X7NmTUZeQ4hcRcItRAAh4ez44483Q4cOtW7uO++80y5fu3atva9WrVrM7apXr15gGRY4iWlY7mR5Z4KKFSsWWLbDDv/v4Itl8QshkkfCLUSAOfDAA+39lClT7H2lSpXs/bJly2Ku/+effxZYRgkYpWAnnnhigedwsRMvj4W7SBBClCwSbiECzOrVq+29K7Nq2bKlvf/yyy8LrEt5FSVhsdzkZKATL4+GLHQS4KKhbKs4Xd4kyMkyFyI2Em4hAsygQYPsfYcOHew9CWl0WsP1TaKag7j47bffHlMMEW4aucRyr7dp08aKNKVdDkq6rr/+elOcVK1a1cbxN2/eXKyvI0QQUVa5EAErB4NVq1aZCRMm2LIrrOKBAwfa5VjOTz/9tDnmmGNszNrVcX/66ae2lSn9zSnTcvzyyy9235SQxQKB/vDDD+3+zjrrLBsDJwOdsi1v1nimoQvct99+a+vRSbSjfIyLE3eBIkQuI+EWIoDlYHQjI0v7sssuM7feequpW7du5DkEm4YrJKy99tprNlv8iCOOsH937969gLUNseLbQJb5q6++avr27WtefPFFawmfdtpptrSsefPmxfZ+KScjDIDnALc/ngLqvyXcQmjIiBA5Bd3HcHu7nz3JbevXrzfTp0/P9qEJIZJEMW4hchRc52SjZ6rpihCiZJCrXIgchRh19NAPIYT/kcUthBBCBAjFuIUQQogAIYtbCCGECBASbiGEECJASLiFEEKIACHhFkIIIQKEhFsIIYQIEBJuIYQQIkBIuIUQQogAIeEWQgghAoSEWwghhAgQEm4hhBAiQEi4hRBCiAAh4RZCCCEChIRbCCGECBASbiGEECJASLiFEEKIACHhFkIIIQKEhFsIIYQIEBJuIYQQIkBIuIUQQogAIeEWQgghAoSEWwghhAgQEm4hhBAiQEi4hRBCiAAh4RZCCCEChIRbCCGECBASbiGEECJASLiFEEKIACHhFkIIIQKEhFsIIYQIEBJuIYQQIkBIuIUQQogAIeEWQgghAoSEWwghhAgQEm4hhBAiQEi4hRBCiACxQ7YPQIhU2Lp1q/n333+zfRhCFCulS5c222+/fbYPQ/gUCbcIBHl5eWbp0qVmzZo12T4UIUqEypUrmxo1apjtttsu24cifIaEWwQCJ9rVqlUzZcuW1clMhPoiddOmTWbZ/7V37kE1dW8cX0hJpaEMkRLlkqEMlRhyyyWaYoZUyN0YBqEUYxB/JbfGMOhmhkFJxqVB45J7SIbuJJcJ88aEmGhM+53v85t9fud0OjnneLucej4zR2evvfbaa6+99azneb579c8/tG1jY9PUXWKaGWy4GYMIj8tG28rKqqm7wzANjqmpKf2E8cZzz2FzRhkWpzHNHjmnDU+bYVoL8vPOmg6mNmy4GYOBw+NMa4Kfd0YTbLiZFsfv37/Fp0+f6GdjHMcwDNOYsOFmWhwwvJ8/f9bLcOtzXFPTu3dvsW/fPtGSSEpKIlV1UzB27Fixdu1aresvWLBA+Pv7N2ifGEYZNtwM00DgFzrCnfIHwropU6aIZ8+eNXXXWhTLly8n8VZKSopOx928eZPuS+1XDM+ePSt27NihdTv79++niYa+hp9hdIUNN8M0IDDUHz58oM+1a9eEkZGRmD59umjuVFdXC0MAr02dOnVKhIeHi4SEhP+kzS5duggLCwut61taWjZZdIBpnbDhZpgGxMTEhBbRwMfV1VVERESId+/eifLyckWdjRs3in79+pGKuE+fPmLLli1qSuILFy4INzc30aFDB2FtbS1mzJih8ZxxcXFkSDBRAJWVlSI4OFiYmZnRO8F79+5V8woRboeXOX/+fNGpUyexbNkyKk9NTRWDBg2i60Cd3bt3q5wLHuu5c+dUynBu2QN9/fo11YEXO27cOLpGFxcXcf/+fZVjUN/Ozo7249qQstAGeNnOzs40rrdu3aKxVebXr180vr169aJrcHR0FPHx8dQv9Ad07tyZ+ogICVAem02bNgkPDw+18+IaoqKi1ELl+J6ZmUleuBxpKS0tpfPGxMSotPH06VPa//LlS62ulWFk2HAzTCPx/ft3cfz4cfolrvw+Orw7GK78/Hz6hX/06FEyrjKXLl0iY+bj4yNycnLIILu7u9d5jujoaDJiV69eFRMmTKCydevWibt374rz58+LjIwMcfv2bfHkyRO1Y2FYYJBwDkwesrOzxezZs8WcOXPE8+fPxbZt26hcOSysLZs3bxYbNmwgY4VJSmBgoEJLkJWVJRYvXixWrVpF+2FQd+7cqVW7MMJz584lr3fq1KlqfcNE5OTJkyI2NlYUFBSIw4cPC3NzczLkmJSAoqIiiohg7GuDCc/Dhw9FSUmJoiwvL4/SHUFBQWr10Yanp6dYunSpItKCCcmiRYtEYmKiSl1sjxkzhp4HhtEJiWGaOVVVVVJ+fj79lKmurpbev39f56e0tFS6c+eOVFxcTN+1/aA+jsN3TW3jvNoSEhIitWvXTjIzM6MP/rvZ2NhI2dnZ9R63a9cuadiwYYptT09PKTg4WGN9e3t7ae/evVJ4eDi1n5ubq9j37ds3qX379lJKSoqi7MuXL1LHjh2lNWvWqLTh7++v0m5QUJDk7e2tUhYWFiY5OzsrtnFNaWlpKnUsLS2lxMRE+o6xRJ24uDjF/ry8PCorKCig7cDAQMnHx0eljYCAAGqnPnC/cG3l5eW0jX44ODhINTU1tF1UVETnycjIqPP4Gzdu0P6KigqVci8vL5WxcXFxkaKiohTbkZGRkoeHh8p99vPz03g8KCsro2chKyuLtvEcWVtbS0lJSTo99wwDeOU0xiDBa1tHjhxp9PMihKzLEpTwHg8dOkTfKyoqxMGDB8kzhBdnb29P5adPnyaPEF4dvHJ4oghXy8ALhQdXHwhh//jxQzx+/JjC7TKvXr2isLuyhw7vtH///mptDB8+XGUbHqqfn59K2ahRo0jBjtXsdFnNa8iQIYrv8vhhVbABAwbQeWqH/uG1Xr58ud42kdOePHkypQ4AIhLw3K9fv07RBowb+ujl5SX+BnjdOBeiDZirwINHFEMXevToIaZNm0bt4F4g9YEw/qxZs/6qb0zrhA03Y5Dgl7Wch60NfiGWlZXRUpH4K0vaAgMHY9KzZ0/Kh2o6ry4gr6wcCkX+GYYT4XCEg5HrhWHYvn07GSHsg9hKOZcsL39ZH6NHj6aQenJyMoXK9QF91RXkaP/neP+fulb6Ur4P8sIiNTU1Ql8wcTh27BitYQ/Bn3I5jCMMtzbjpg0I6yNPjvRCVVUV5dEDAgJ0bmfJkiVi3rx5lAZBmBxt8GqAjD6w4WYMEhgCTZ7vz58/yXgjjwkxl7bgOBgTCMl0OU4XYLTatm1LBgDcu3ePPG/kgGXevHmj5q0ir71w4UKN7cKLQ44YKnYYMuSTAbxvjNWjR48o1wq+fv0qiouLKb9aHwMHDqTcuDLYRo5a9ra7du1KeVyZFy9ekNJbF3Ae5LmVefDgQb3HpKenk+gO+Xhlzz83N5fGCa94DR48mO4nxGITJ05Ua8PY2Fhh7OvD1taWvPYTJ07QffP29qZJoSbQbl1tIiKAyREiMIgmQEzHMPrAhpthGhBMIOAVyqHyAwcOUDjc19eXypycnMTbt2/Jy4ZqHF5zWlqaShtbt24lD7Jv374kFEMoHYYLXqAyI0eOpHKE4mG8oYyG8C0kJESEhYXRa04wOGgPk4c/Lam5fv166hPU5vAOER1A/xHulxk/fjyVIbQNY4U+6RLlAKtXr6YQPMRxCM1fuXLlj2FyiNIQeoaYThkozENDQ8nIrly5kq4dwjCkIlAXkyJEVSC6w4QJY3Dx4kUyqvDQIVyrC0RFMG54TU5ZOFgXUN9jIgLlOtrDuGO8McGA6jwyMpLuO8aMYfSCU/1Mc0dXkQ7qFRYW6izq0fc4TUC0hP9i8sfCwkJyc3OTzpw5oyb4srKykszNzUmUBaFZbWFWamqq5OrqKhkbG5OoaebMmWriNJnMzEwSw8XGxioEahCaQZDWvXt3ac+ePZK7u7sUERGhsQ0Z9BViNIjA7OzsSDhXW3Q1adIkOp+Tk5OUnp5epzgtJydHcQzEYCiDOEwmPj5esrW1lUxNTSVfX18pJiZGozjt48ePkpGRkZScnFzn/hUrVkhDhw6l77iXoaGhJNrD2Dk6OkoJCQmKuhCdYUzatGlD90uTuAx9NjExoTGsrKxU2VdbnAZR3IgRI+hacJ0YA5mSkhIqi46Olv4Ei9MYTbTBP/qZfIZpHBDCxruwDg4OWoWwUR+eFTwqXUPl+hxnaEDEhjw+8ugQczGNB17FQ/QEefJu3br9p88903rgUDnDtHCQBy4sLKQ8OPLb8sIhtRXjTMOmTLDoDt6Fh5L8T0abYeqDF2BhWhzI72KBE2W1cUMeZwjIi6tApAWPG56frgp5Rn/wChkiORDNYZEchvkbOFTONHs4ZMi0Rvi5ZzTBHjfDMAzDGBBsuBmDgYNDTGuCn3dGE2y4mWaP/F6wrgt7MIwhIz/vur4Xz7R8Wp4Kh2lxYOEK/KlILJwBsEzknxYPYRhD9rRhtPG847nXZU14pnXA4jTGIMBjihXIoMplmNYAjDaW3+VJKlMbNtyMQYFlNev6IxYM05JAeJw9bUYTbLgZhmEYxoBgcRrDMAzDGBBsuBmGYRjGgGDDzTAMwzAGBBtuhmEYhjEg2HAzDMMwjAHBhpthGIZhDAg23AzDMAwjDId/AWgg3qQ2n7FYAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 500x1000 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "import matplotlib.patches as patches\n",
     "\n",


### PR DESCRIPTION
Automate the ptsrc input to csv rather than manual merging of csvs
- Added a helper function reshape_canberra_with_ptsrc_mixed() to post-process the mixed Canberra + PtSrc dataframe before saving. -Ensures Canberra rows and PtSrc rows are matched by depth interval parsed from filenames. -Added three new output columns (H/I/J) immediately after Pb-214 error: ptsrc_pb210, ptsrc_pb210 error, file ptsrc (filename only, not full path)

Version handling of PDFs
-Improved depth/filename parsing regex to handle: depths with or without "cm", optional version suffixes (_v2, _v3, …) When multiple files exist for the same depth:
-Canberra side: keep the file with the highest version number. -PtSrc side: keep the file with the highest version number. -Non-versioned files are treated as version 0.

Integration
-Updated the CSV export step (extract_pdf_values) to use the new helper so output is automatically reordered and cleaned before saving.